### PR TITLE
Introduction of PM för PIFF och PUFF - SM#3 2020 - 2020-09-28

### DIFF
--- a/pm/eng/00_pm_for_pm.md
+++ b/pm/eng/00_pm_for_pm.md
@@ -81,5 +81,6 @@ Memo for Studiemiljönämden, 2008-12-11
 Memo for Studienämden, 2008-12-11  
 Memo for Traditions, 2014-12-08  
 Memo for TraditionsMEsterIT, 2008-12-11  
-Memo for the Elections Committee, 2014-02-10
-Memo for Stickkontaktsansvarig, 2019-02-23
+Memo for the Elections Committee, 2014-02-10  
+Memo for Stickkontaktsansvarig, 2019-02-23  
+Memo for PIFF and PUFF, 2020-09-28

--- a/pm/eng/00_pm_for_pm.md
+++ b/pm/eng/00_pm_for_pm.md
@@ -9,7 +9,7 @@ The purpose of this memo is to formulate and to regulate the form and structure 
 ### 1.2 History
 
 Created: 2008-12-11  
-Last revision: 2014-12-07
+Last revision: 2020-09-28
 
 ### 1.3 Revising this Memo
 

--- a/pm/eng/pm_for_piff_och_puff.md
+++ b/pm/eng/pm_for_piff_och_puff.md
@@ -1,0 +1,88 @@
+# Memo for PIFF och PUFF
+
+## 1 Formalities
+
+### 1.1 Purpose
+
+The purpose of this Memo is to regulate the committee *PIFF och PUFF*.
+
+### 1.2 History
+
+Created: 2020-09-28  
+Last revision: 2020-09-28
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this memo, a decision has to be made with a qualified majority at two subsequent chapter meetings.
+
+## 2 Organisation
+
+### 2.1 Factions
+
+The committee consists of three factions, called *P*, *I*, and *F*.
+
+### 2.2 Members
+
+Each member of the committee belongs to one or more factions.
+
+### 2.3 Faction Members
+
+A member of a faction shall forever be considered a member of the faction.
+
+A member of the committee may be part of multiple fractions, but may never be an active member in more than one fraction at a time.
+
+### 2.4 Faction President
+
+Each fraction has a president, known as "*Förste-*" or "*First-*" followed by the faction's letter, e.g. "*First-P*".
+
+### 2.5 Active Faction Member
+
+Each faction has its own active members, who are adressed with the faction's letter followed by the suffix "*-ar*e" or "*-er*", e.g. "*P-er*".
+
+The president of a faction is considered an active member of the faction.
+
+### 2.6 Previously Active Faction Member
+
+All previously active members in each of the factions shall be considered members of the faction even after concluding their time as active members.
+
+Previously active members are adressed "*Gammel-*" followed by the faction's letter, e.g. "*Gammel-P*".
+
+## 3 Elections
+
+### 3.1 Election of Faction President
+
+Each faction President shall nominate a successor.  
+The nomination is based on an audition where all chapter members may participate.
+
+All members of the faction have the right to attend the audition, and state their opinion about the suitability of any candidates.
+
+In the event that a faction is missing a president, or that the president is seeking to be reelected, the active members of the faction are responsible for conducting the process.
+
+### 3.2 Election of Active Faction Members
+
+Each newly elected faction president shall select active members for their operational year.  
+The selection is based on an audition where all chapter members may participate.
+
+All members of the faction have the right to attend the audition, and state their opinion about the suitability of any candidates.
+
+## 4 Meetings
+
+### 4.1 Meeting
+
+The committee shall at least once per year hold a meeting, known as "*PIFF Uppmärksammar Formalia och Förbereder*", shortened "*PUFF*".
+
+### 4.2 Meeting Minutes
+
+Meeting minutes shall be kept during PUFF.
+
+The meeting minutes does not need to be openly published, but shall be available to all members of the committee within a month of the day of the meeting.
+
+## 5 Responsibilities
+
+The committee shall in its work aid the chapter's members in various ways.
+
+The factions may independently plan the execution of this task.
+
+### 5.1 Information Sharing
+
+If the committee or any of its factions deviate from the rules set forth in this Memo, or from any formally made plans, the members of the committee shall urgently inform the chapter's board.

--- a/pm/swe/00_pm_for_pm.md
+++ b/pm/swe/00_pm_for_pm.md
@@ -9,7 +9,7 @@ Syftet med denna PM är att formalisera samt reglera hur sektionens PM skall se 
 ### 1.2 Historik
 
 Upprättat: 2008-12-11  
-Senast ändrat: 2019-02-23
+Senast ändrat: 2020-09-28
 
 ### 1.3 Ändrande av PM
 

--- a/pm/swe/00_pm_for_pm.md
+++ b/pm/swe/00_pm_for_pm.md
@@ -9,7 +9,7 @@ Syftet med denna PM är att formalisera samt reglera hur sektionens PM skall se 
 ### 1.2 Historik
 
 Upprättat: 2008-12-11  
-Senast ändrat: 2014-12-07
+Senast ändrat: 2019-02-23
 
 ### 1.3 Ändrande av PM
 
@@ -81,5 +81,6 @@ PM för Studiemiljönämnden, 2008-12-11
 PM för Studienämnden, 2008-12-11  
 PM för Traditioner, 2014-12-08  
 PM för TraditionsMEsterIT, 2008-12-11  
-PM för Valberedningen, 2014-02-10
-PM för Stickkontaktsansvarig, 2019-02-23
+PM för Valberedningen, 2014-02-10  
+PM för Stickkontaktsansvarig, 2019-02-23  
+PM för Piff och Puff, 2020-09-28

--- a/pm/swe/pm_for_piff_och_puff.md
+++ b/pm/swe/pm_for_piff_och_puff.md
@@ -1,0 +1,90 @@
+# PM för PIFF och PUFF
+
+## 1 Formalia
+
+### 1.1 Syfte
+
+Syftet med denna PM är att reglera nämnden *PIFF och PUFF*
+
+### 1.2 Historik
+
+Upprättat: 2020-09-28  
+Senast ändrat: 2020-09-28
+
+### 1.3 Ändrande av PM
+
+För ändrande av denna PM krävs ett beslut taget med kvalificerad majoritet på två på varandra följande SM.
+
+## 2 Organisation
+
+### 2.1 Fraktioner
+
+Nämnden utgörs av tre fraktioner, som benämns *P*, *I*, och *F*.
+
+### 2.2 Medlemmar
+
+Varje nämndmedlem hör till en eller flera fraktioner.
+
+### 2.3 Fraktionsmedlemmar
+
+En medlem i en fraktion är att betrakta som medlem i fraktionen för all framtid.
+
+En nämndmedlem kan vara medlem i flera fraktioner, men aldrig aktiv medlem i mer än en fraktion samtidigt.
+
+### 2.4 Fraktionsledare
+
+Varje fraktion har en ledare, som tituleras "*Förste-*" eller "*First-*" följt av fraktionens bokstav, t.ex. "*Förste-P*".
+
+### 2.5 Aktiv Medlem i Fraktion
+
+Varje fraktion har sina egna aktiva medlemmar, som benämns med fraktionens bokstav följd av suffixet "*-are*" eller "*-er*", t.ex. "*P-are*".
+
+En fraktions ledare är att betrakta som en aktiv medlem i fraktionen.
+
+### 2.6 Tidigare Aktiv Medlem i Fraktion
+
+Alla tidigare aktiva medlemmar i de respektive fraktionerna är att betrakta som medlemmar även efter att de inte längre är att betrakta som aktiva medlemmar.
+
+Tidigare aktiva medlemmar tituleras "*Gammel-*" följt av fraktionens bokstav, t.ex. "*Gammel-P*".
+
+## 3 Val
+
+### 3.1 Val av Fraktionsledare
+
+Varje fraktions ledare skall nominera en efterträdare.  
+Nomineringen skall baseras på en uttagning där alla sektionsmedlemmar har möjlighet att söka.
+
+Alla fraktionens medlemmar har rätt att delta på uttagningen, och att lämna sin åsikt rörande kandidaternas respektive lämplighet.
+
+Om en fraktion saknar en ledare, eller om ledaren önskar väljas om, faller ansvaret att genomföra uttagningsprocessen på fraktionens övriga aktiva medlemmar.
+
+Den nominerade personen godkännes av sektionsmötet.
+
+### 3.2 Utnämnande av Aktiva Medlemmar
+
+Varje nyvald fraktionsledare skall välja aktiva medlemmar för sitt verksamhetsår.  
+Valet skall baseras på en uttagning där alla sektionsmedlemmar har möjlighet att söka.
+
+Alla fraktionens medlemmar har rätt att delta på uttagningen, och att lämna sin åsikt rörande kandidaternas respektive lämplighet.
+
+## 4 Möten
+
+### 4.1 Möte
+
+Nämnden skall minst en gång per år hålla möte, benämnt "*PIFF Uppmärksammar Formalia och Förbereder*", förkortat "*PUFF*"
+
+### 4.2 Protokoll
+
+Mötesprotokoll skall föras under PUFF.
+
+Protokollet behöver inte publiceras öppet, men skall göras tillgängligt för alla nämndens medlemmar inom en månad från mötesdagen.
+
+## 5 Ansvar
+
+Nämnden skall arbeta för att hjälpa sektionens medlemmar på olika sätt.
+
+Fraktionerna tillåts att självständigt planera utförandet av denna uppgift.
+
+### 5.1 Informationsspridning
+
+Om nämnden eller någon av dess fraktioner frångår bestämmelserna i denna PM eller några formellt upprättade planer skall nämndens medlemmar snarast informera sektionens styrelse.


### PR DESCRIPTION
This PR adds PM för PIFF och PUFF / Memo for PIFF och PUFF.

They were introduced via a proposition from the chapter's board at SM#3 2020, which took place on 2020-09-28.

[SM#3 2020 Meeting Minutes](https://drive.google.com/file/d/192YDywsihG_rqwpshy1jGoL0Sy37dwwB/view)
[Proposition](https://docs.google.com/document/d/1mI5wyA8OkFMaysT1-oDJffzv01qQ3L4e/edit)
[Revised version of the proposed Memo](https://docs.google.com/document/d/1vzkxbImgA-FA6_BdsLUhUMroOr-Ku8I5/edit)

Please note that the proposed memo lacks a Swedish version and is written in a fairly convoluted fashion.  
For that reason I have taken the liberty of first translating the provided text into Swedish, and then writing an English version.  
Both of which should be a bit easier to understand than the original text, while still retaining the meaning of the original text.