### PR TITLE
Add board member for history management - SM#2 2019 - 2019-05-21

### DIFF
--- a/pm/eng/pm_for_sektionens_styrelse.md
+++ b/pm/eng/pm_for_sektionens_styrelse.md
@@ -9,7 +9,7 @@ The purpose of this Memo is to formulate and to regulate the chapter's Board's c
 ### 1.2 History
 
 Created: 2008-12-11  
-Last revision: 2015-01-01
+Last revision: 2019-09-17
 
 ### 1.3 Revisions to this Memo
 
@@ -29,7 +29,7 @@ The Chapter's board is composed of:
 - a board member responsible for student social activities
 - a board member responsible for business relations
 - a board member responsible for communication
-- a board member
+- a board member responsible for the history and future of the chapter
 - a board member
 
 ### 2.2 Deputies
@@ -132,7 +132,17 @@ The board member shall act as a support for them, as well as a link between the 
 The board member shall be responsible for holding a meeting with the committee before every board meeting to ensure a good insight to their work and to ensure the possibility to answer and forward their questions to the board and vice versa.  
 The board member shall actively cooperate with and attend meetings arranged by THS Kommunikationsråd.
 
-### 3.2.9 Other board members and deputies
+### 3.2.9 Board member responsible for the chapter's history and future
+
+The board member with responsibility for the chapters history and future shall document and bring to life the chapter’s history.
+This shall be done in such a way that all future chapter activity can have use of the work, and that all chapter members can partake in the information.
+
+The board member shall contribute with information regarding the chapter’s past and earlier work to assist the chapter and the board in their function and activity.
+The board member shall also work with the board to preserve the chapter in the long term.
+
+The board member is also responsible for management of the communication with the chapter’s alumni.
+
+### 3.2.10 Other board members and deputies
 
 The remaining board members are reaponsible for working with the boards strategic questions as well as the areas the board consider important.  
 The vice treasurer is regulated under point 3.2.4.

--- a/pm/swe/pm_for_sektionens_styrelse.md
+++ b/pm/swe/pm_for_sektionens_styrelse.md
@@ -9,7 +9,7 @@ Syftet med denna PM är att formalisera samt reglera sektionens Styrelses samman
 ### 1.2 Historik
 
 Upprättat: 2008-12-11  
-Senast ändrat: 2015-01-01
+Senast ändrat: 2019-09-17
 
 ### 1.3 Ändrande av PM
 
@@ -21,15 +21,15 @@ För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet p�
 
 Sektionens styrelse består av:  
 
-- Sektionens ordförande  
-- Sektionens vice ordförande  
-- Sektionens sekreterare  
-- Sektionens kassör  
-- Ledamot med ansvar för utbildningspåverkan  
-- Ledamot med ansvar för studiesocial verksamhet  
-- Ledamot med ansvar för näringslivssamverkan  
-- Ledamot med ansvar för kommunikation  
-- Ledamot  
+- Sektionens ordförande
+- Sektionens vice ordförande
+- Sektionens sekreterare
+- Sektionens kassör
+- Ledamot med ansvar för utbildningspåverkan
+- Ledamot med ansvar för studiesocial verksamhet
+- Ledamot med ansvar för näringslivssamverkan
+- Ledamot med ansvar för kommunikation
+- Ledamot med ansvar för sektionens historia och framtid
 - Ledamot
 
 ### 2.2 Suppleanter
@@ -132,7 +132,17 @@ Ledamoten fungerar även som stöd för dessa, samt som en länk mellan Kommunik
 Ledamoten ansvarar för att kalla till möte med Kommunikationsnämnden innan varje styrelsemöte, för att säkra en bra insyn i deras arbete samt möjligheten att besvara och driva deras frågor till styrelsen och vice versa.  
 Ledamoten ska aktivt samarbeta med och delta i möten anordnat av THS Kommunikationsråd.
 
-#### 3.2.9 Övriga ledamöter och suppleanter
+#### 3.2.9 Ledamot med ansvar för sektionens historia och framtid
+
+Ledamoten med ansvar för sektionens historia och framtid skall dokumentera och levandegöra sektionens historia.
+Detta skall ske på ett sådant sätt att all framtida verksamhet sektionen bedriver kan ha nytta av arbetet och att alla sektionsmedlemmar kan ta del av det.
+
+Ledamoten ska bidra med information om sektionens förflutna och tidigare arbete för att assistera sektionen och styrelsen i deras verksamhet.
+Ledamoten skall även arbeta tillsammans med styrelsen för att långsiktigt bevara sektionen.
+
+Ledamoten är också ansvarig för att hantera kommunikationen med sektionens alumner.
+
+#### 3.2.10 Övriga ledamöter och suppleanter
 
 Resterande styrelseledamöter ansvarar för att jobba med styrelsens strategiska frågor samt de områden som styrelsens strategiska frågor som styrelsen anser vara lämpliga.  
 Vice kassörs ansvar regleras av punkt 3.2.4.


### PR DESCRIPTION
This PR changes the composition of the chapter's board to include a board member responsible for managing the chapter's history.

The changes were introduced via a proposition from the chapter's board at SM#2 2019

[SM#2 2019 Meeting Minutes](https://drive.google.com/file/d/1AMPy6EjF8r3fScZOIbT85H9uFaFQyb_3/view)
[Proposition](https://docs.google.com/document/d/1CBrCwVHmyq-AUHEAceLHfM_NaF5TnhaIO8k_E0oElxk/view)

Minor edits to the phrasing were made to ensure clarity.