### PR TITLE
Introduction of PM för Förtroendevalda Positioner and changes to Memos - SM#4 2021 - 2021-11-29

### DIFF
--- a/pm/eng/00_pm_for_pm.md
+++ b/pm/eng/00_pm_for_pm.md
@@ -62,26 +62,27 @@ The list may be changed without a decision from the chapter meeting when new Mem
 ### 3.2 PM
 
 Memo for Memos, 2008-12-11  
+Memo for Business Relations Committee, 2008-12-11  
+Memo for Communication Committee, 2014-01-01  
+Memo for Graphical Profile, 2017-05-23  
 Memo for History Responsible, 2021-02-25  
-Memo for Graphical Profile 2017-05-23  
-Memo for Idrottsnämden, 2008-12-11  
+Memo for ITerativa Klubben, 2008-12-11  
 Memo for Information, 2008-12-11  
 Memo for Insignia, 2013-10-16  
-Memo for Iterativa klubben, 2008-12-11  
-Memo for Kommunikationsnämden, 2014-01-01  
-Memo for Mottagningsnämden, 2008-12-11  
-Memo for Business Relations Board, 2008-12-11  
+Memo for PIFF and PUFF, 2020-09-28
 Memo for Qlubbmästeriet IN-Sektionen Kista, 2009-05-15  
-Memo for the Chapter's Profile, 2014-02-10  
-Memo for The Chapter Board, 2008-12-11  
-Memo for The Chapter's Locals, 2008-12-11  
-Memo for the Chapter Standard, 2011-12-08  
-Memo for the Safety Officer, 2014-09-22  
-Memo for Studiemiljönämden, 2008-12-11  
-Memo for Studienämden, 2008-12-11  
-Memo for Traditions, 2014-12-08  
-Memo for TraditionsMEsterIT, 2008-12-11  
-Memo for the Elections Committee, 2014-02-10  
+Memo for Reception Committee, 2008-12-11  
+Memo for Sports Committee, 2008-12-11  
 Memo for Stickkontaktsansvarig, 2019-02-23  
 Memo for Student Social Committee, 2020-05-20  
-Memo for PIFF and PUFF, 2020-09-28
+Memo for Study Committee, 2008-12-11  
+Memo for Study Enviroment Committee, 2008-12-11  
+Memo for Traditions, 2014-12-08  
+Memo for TraditionsMEsterIT, 2008-12-11  
+Memo for Trustee Elected Positions, 2021-11-29  
+Memo for the Chapter Board, 2008-12-11  
+Memo for the Chapter Standard, 2011-12-08  
+Memo for the Chapter's Locals, 2008-12-11  
+Memo for the Chapter's Profile, 2014-02-10  
+Memo for the Elections Committee, 2014-02-10  
+Memo for the Safety Officer, 2014-09-22  

--- a/pm/eng/pm_for_fortroendevalda_positioner.md
+++ b/pm/eng/pm_for_fortroendevalda_positioner.md
@@ -1,0 +1,116 @@
+# Memo for Trustee Elected Positions
+
+## 1 Formalities
+
+### 1.1 Purpose
+
+The purpose of this Memo is to list all of the chapter's trustee elected positions.
+
+### 1.2 History
+
+Created: 2021-11-29  
+Last revision: 2021-11-29
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
+
+## 2 List of the chapter's trustee elected positions
+
+### 2.1 Instructions
+
+All elected positions must be listed under point 2.2 with their names and, in the case that there is more than one, how many can hold the position at the same time.
+
+The list may be changed without decisions at SM, where after SM decides on changes to statutes or PMs that result in changes to which elected positions are in the chapter.
+
+### 2.2 Trustee Elected
+
+#### 2.2.1 Chapter Board
+
+-   Chapter President
+-   Chapter vice President
+-   Chapter Secretary
+-   Chapter Cashier
+-   Board member responsible for education influence
+-   Board member responsible for student social activities
+-   Board member responsible for business relations
+-   Board member responsible for communication
+-   Board member – two
+-   Chapter vice Cashier
+
+#### 2.2.2 Studiemiljönämnden
+
+-   StURe
+-   Lill-StURe
+
+#### 2.2.3 Studiesocialanämnden
+
+-   vice President with responsibility for JML
+
+#### 2.2.4 Studienämnden
+
+-   PAS CINTE
+-   PAS TCOMK
+-   PAS TIDAB
+-   PAS TIEDB
+-   PAS Master
+
+#### 2.2.5 Näringslivsnämnden
+
+- vice President
+- Responsible for Kista Arbetsmarknadsdag (KAM)
+ 
+#### 2.2.6 Kommunikationsnämnden
+
+- vice President
+
+#### 2.2.7 Idrottsnämnden
+
+- President
+- vice President
+
+#### 2.2.8 Mottagningen
+
+- INGEN
+- NÅGON
+- Member - three
+
+#### 2.2.9 PIFF och PUFF
+
+- First P
+- First I
+- First F
+
+#### 2.2.10 TMEIT
+
+- TranditionsMästare
+- vice TraditionsMästare
+
+#### 2.2.11 QMISK
+
+- QlubbMästare
+- vice QlubbMästare
+
+#### 2.2.12 ITK
+
+- Root
+- Sudo
+
+#### 2.2.13 The Link
+
+- President
+- vice President
+
+#### 2.2.14 The Elections Committee
+
+- Convener
+- Member - at least 4
+
+#### 2.2.15 Andra Positioner
+
+- Auditor - two
+- Safety officer
+- History Responsible
+- Standard bearer
+- vice Standard bearer
+- Stickkontaktsansvarig

--- a/pm/eng/pm_for_mottagningsnamnden.md
+++ b/pm/eng/pm_for_mottagningsnamnden.md
@@ -15,17 +15,14 @@ Last revision: 2019-05-21
 
 The Reception committee is made up by at least:
 
-- Chairperson and main responsible, called INitiationsGENeral (INGEN), who has the main responsibility and final say regarding the Reception.  
-  INGEN is elected by the chapter meeting.  
-- Deputy chairperson. Shall in the absence of INGEN carry out INGEN's duties and execute INGEN's responsibilities.  
-  Is responsible for the economy and contact for the chapter's treasurer.  
-  The vice chairperson is also responsible for the work delegated to them by INGEN by mutual agreement.  
-  Is elected by the chapter meeting.  
-- Three board members. Their areas of responsibilitiy is decided by the Reception committee.  
-  They are elected by the chapter meeting.  
-- One main responsible from each föseri.  
-  They are nominated by the current responsible and are approved by the chapter meeting.  
-  The nomination is based on a draft where all chapter members may participate.
+-   Chairperson and main responsible, called INitiationsGENeral (INGEN), who has the main responsibility and final say regarding the Reception.  
+    INGEN is elected by the chapter meeting.
+-   Deputy chairperson. Shall in the absence of INGEN carry out INGEN's duties and execute INGEN's responsibilities.  
+    Is responsible for the economy and contact for the chapter's treasurer.  
+    The vice chairperson is also responsible for the work delegated to them by INGEN by mutual agreement.  
+    Is elected by the chapter meeting.
+-   Three board members. Their areas of responsibilitiy is decided by the Reception committee.  
+    They are elected by the chapter meeting.
 
 The Reception's management/leadership, regulated by the Reception's rules, are themselves responsible for creating the structure within the committee.  
 In addition to this the Reception committee may freely define and assign additional areas of responsibility to handle questions such as specific events and marketing.

--- a/pm/swe/00_pm_for_pm.md
+++ b/pm/swe/00_pm_for_pm.md
@@ -61,27 +61,28 @@ Listan får ändras utan att beslut behöver fattas på SM, var efter SM besluta
 
 ### 3.2 PM
 
-PM för PM, 2008-12-11.  
+PM för PM, 2008-12-11  
+PM för Förtroendevalda Positioner 2021-11-29  
+PM för Grafisk Profil, 2017-05-23  
 PM för Historieansvarig, 2021-02-25  
-PM för Grafisk profil 2017-05-23  
 PM för Idrottsnämnden, 2008-12-11  
 PM för Information, 2008-12-11  
 PM för Insignia, 2013-10-16  
-PM för Iterativa klubben, 2008-12-11  
+PM för ITerativa Klubben, 2008-12-11  
 PM för Kommunikationsnämnden, 2014-01-01  
 PM för Mottagningsnämnden, 2008-12-11  
 PM för Näringslivsnämnden, 2008-12-11  
+PM för PIFF och PUFF, 2020-09-28  
 PM för Qlubbmästeriet IN-sektionen Kista, 2009-05-15  
-PM för Sektionens profil, 2014-02-10  
-PM för Sektionens styrelse, 2008-12-11  
-PM för Sektionens utrymmen, 2008-12-11  
+PM för Sektionens Profil, 2014-02-10  
+PM för Sektionens Styrelse, 2008-12-11  
+PM för Sektionens Utrymmen, 2008-12-11  
 PM för Sektionsfanan, 2011-12-08  
 PM för Skyddsombud, 2014-09-22  
+PM för Stickkontaktsansvarig, 2019-02-23  
 PM för Studiemiljönämnden, 2008-12-11  
 PM för Studienämnden, 2008-12-11  
+PM för Studiesociala nämnden, 2020-05-20  
 PM för Traditioner, 2014-12-08  
 PM för TraditionsMEsterIT, 2008-12-11  
 PM för Valberedningen, 2014-02-10  
-PM för Stickkontaktsansvarig, 2019-02-23  
-PM för Studiesociala nämnden, 2020-05-20  
-PM för Piff och Puff, 2020-09-28

--- a/pm/swe/pm_for_fortroendevalda_positioner.md
+++ b/pm/swe/pm_for_fortroendevalda_positioner.md
@@ -1,0 +1,117 @@
+# PM för Förtroendevalda Positioner
+
+## 1 Formalia
+
+### 1.1 Syfte
+
+Denna PM är avsedd till att lista alla sektionens förtroendevalda positioner.
+
+### 1.2 Historik
+
+Upprättat: 2021-11-29
+
+Senast ändrat: 2021-11-29
+
+### 1.3 Ändrande av PM
+
+För ändrande av denna PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
+
+## 2 Lista av sektionens förtroendevalda positioner
+
+### 2.1 Instruktioner
+
+Samtliga av förtroendevalda positioner skall listas under punkt 2.2 med deras namn och i fallet att det är mer än en hur många som kan hålla positionen vid samma gång.
+
+Listan får ändras utan att beslut behöver fattas på SM, var efter SM beslutar om förändringar till stadgar eller PM som resulterar i förändringar till vilka förtroendevalda positioner som finns i sektionen.
+
+### 2.2 Förtroendevalda
+
+#### 2.2.1 Sektionsstyrelsen
+
+-   Sektionens Ordförande
+-   Sektionens vice Ordförande
+-   Sektionens Sekreterare
+-   Sektionens Kassör
+-   Styrelseledamot med ansvar för Utbildningspåverkan
+-   Styrelseledamot med ansvar för Studiesocial verksamhet
+-   Styrelseledamot med ansvar för Näringslivssamverkan
+-   Styrelseledamot med ansvar för Kommunikation
+-   Styrelseledamot – två
+-   Sektionens vice Kassör
+
+#### 2.2.2 Studiemiljönämnden
+
+-   StURe
+-   Lill-StURe
+
+#### 2.2.3 Studiesocialanämnden
+
+-   vice Ordförande med ansvar för JML
+
+#### 2.2.4 Studienämnden
+
+-   PAS CINTE
+-   PAS TCOMK
+-   PAS TIDAB
+-   PAS TIEDB
+-   PAS Master
+
+#### 2.2.5 Näringslivsnämnden
+
+- vice Ordförande
+- Ansvarig för Kista Arbetsmarknadsdag (KAM)
+ 
+#### 2.2.6 Kommunikationsnämnden
+
+- vice Ordförande
+
+#### 2.2.7 Idrottsnämnden
+
+- Ordförande
+- vice Ordförande
+
+#### 2.2.8 Mottagningen
+
+- INGEN
+- NÅGON
+- Ledamot - tre
+
+#### 2.2.9 PIFF och PUFF
+
+- Första P
+- Första I
+- Första F
+
+#### 2.2.10 TMEIT
+
+- TranditionsMästare
+- vice TraditionsMästare
+
+#### 2.2.11 QMISK
+
+- QlubbMästare
+- vice QlubbMästare
+
+#### 2.2.12 ITK
+
+- Root
+- Sudo
+
+#### 2.2.13 The Link
+
+- Ordförande
+- vice Ordförande
+
+#### 2.2.14 Valberedningen
+
+- Sammankallande
+- Medlem - minst 4
+
+#### 2.2.15 Andra Positioner
+
+- Revisor - två
+- Skyddsvårdsombud
+- Historieansvarig
+- Fanbärare
+- vice Fanbärare
+- Stickkontaktsansvarig

--- a/pm/swe/pm_for_mottagningsnamnden.md
+++ b/pm/swe/pm_for_mottagningsnamnden.md
@@ -13,24 +13,21 @@ Senast ändrat: 2019-05-21
 
 ## 2 Organisation
 
-Mottagningsnämnden består som minst av:  
+Mottagningsnämnden består som minst av:
 
-- Ordförande och huvudansvarig, benämnd INitiationsGENeral (INGEN), som har det yttersta ansvaret och ordet avseende Mottagningen som helhet.  
-  Väljs av SM.  
-- Vice ordförande.  
-  Ska i INGENs frånvaro utöva dennes befogenheter, och fullgöra dennes plikter.  
-  Är ekonomisk samordnare och fungerar som kontaktperson med sektionens kassör.  
-  Utöver detta innehar vice ordförande det ansvar som fördelas mellan denne och ordförande efter gemensam överenskommelse.  
-  Väljs av SM.  
-- Tre ledamöter i Mottagningsnämndens styrelse.  
-  Deras ansvarsområden bestäms av mottagningsnämnden i början av verksamhetsåret.  
-  De väljs av SM.  
-- En huvudansvarig från varje föseri.  
-  Nomineras av sittande huvudansvarig och godkännes av SM.  
-  Nomineringen baseras på en uttagning där alla sektionsmedlemmar har möjlighet att söka.
+-   Ordförande och huvudansvarig, benämnd INitiationsGENeral (INGEN), som har det yttersta ansvaret och ordet avseende Mottagningen som helhet.  
+    Väljs av SM.
+-   Vice ordförande.  
+    Ska i INGENs frånvaro utöva dennes befogenheter, och fullgöra dennes plikter.  
+    Är ekonomisk samordnare och fungerar som kontaktperson med sektionens kassör.  
+    Utöver detta innehar vice ordförande det ansvar som fördelas mellan denne och ordförande efter gemensam överenskommelse.  
+    Väljs av SM.
+-   Tre ledamöter i Mottagningsnämndens styrelse.  
+    Deras ansvarsområden bestäms av mottagningsnämnden i början av verksamhetsåret.  
+    De väljs av SM.
 
 Mottagningens ledning, reglerat av Mottagningens reglemente, bygger själva upp strukturen inom nämnden.  
-Utöver detta står det Mottagningsnämnden fritt att internt definiera och tilldela ytterligare ansvarsposter för att hantera frågor såsom exempelvis evenemangsansvar och marknadsföring.  
+Utöver detta står det Mottagningsnämnden fritt att internt definiera och tilldela ytterligare ansvarsposter för att hantera frågor såsom exempelvis evenemangsansvar och marknadsföring.
 
 Mottagningsnämnden ska aktivt verka för att inkludera övriga nämnder i sina aktiviteter.
 


### PR DESCRIPTION
Adds a new memo for Trustee Elected Positions and edits to old memos.

[SM#4 2021 Protocol](https://drive.google.com/file/d/1sAqtFWtzScq6cGsm5jPzKJEaGshP7s4Y/view)
[Proposition regarding removing PIFF och PUFF redundancy](https://docs.google.com/document/d/1fvwLfznRQrxxGPFLaiFCkMjhLfGyPu28/edit)
[Proposition regarding Memo for Trustee Elected Positions
](https://docs.google.com/document/d/1bjr7ncVT67OEom0OyYkgPGXtBas1FWVp/edit)

Memo for Memo point 3.2 were sorted in alphabetical order.

Minor edits to the phrasing were made to ensure clarity.