### PR TITLE
Add missing Point §1.3 Revising this Memo - SM#3 2022 - 2022-09-27

### DIFF
--- a/pm/eng/pm_for_historieansvarig.md
+++ b/pm/eng/pm_for_historieansvarig.md
@@ -9,7 +9,11 @@ The purpose of this PM is to regulate the Chapters’ History Responsible.
 ### 1.2 History
 
 Established: 2021-02-25
-Last revision: 2021-02-25
+Last revision: 2022-09-27
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
 
 ## 2 Responsibility
 

--- a/pm/eng/pm_for_idrottsnamnden.md
+++ b/pm/eng/pm_for_idrottsnamnden.md
@@ -11,7 +11,11 @@ The purpose of the Sports Committee is to encourage physical activities in the c
 ### 1.2 History
 
 Created: 2008-12-11  
-Last revision: 2014-10-07
+Last revision: 2022-09-27
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
 
 ## 2 Organisation
 

--- a/pm/eng/pm_for_information.md
+++ b/pm/eng/pm_for_information.md
@@ -9,7 +9,11 @@ The purpose of this memo is to regulate the chapter's official channels for info
 ### 1.2 History
 
 Created: 2008-12-11  
-Last revision: 2021-02-25
+Last revision: 2022-09-27
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
 
 ## 2 Official channels for information
 

--- a/pm/eng/pm_for_insigna.md
+++ b/pm/eng/pm_for_insigna.md
@@ -11,7 +11,7 @@ The purpose of this memo is to regulate the chapter's insignia.
 Created: 2013-10-16  
 Last revision: 2021-02-25
 
-## 1.3 Change
+### 1.3 Revising this Memo
 
 To change this memo a decision needs to be made with qualified majority on two chapter meetings in a row.
 

--- a/pm/eng/pm_for_iterativa_klubben.md
+++ b/pm/eng/pm_for_iterativa_klubben.md
@@ -10,7 +10,11 @@ The purpose of the ITerative Club is to arrange events for the chapter's members
 ### 1.2 History
 
 Created: 2008-12-11  
-Last revision: 2021-02-25
+Last revision: 2022-09-27
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
 
 ## 2 Organisation
 

--- a/pm/eng/pm_for_kommunikationsnamnden.md
+++ b/pm/eng/pm_for_kommunikationsnamnden.md
@@ -11,7 +11,11 @@ The purpose of the Communication Committee is to coordinate communication, flow 
 ### 1.2 History
 
 Created: 2014-01-01  
-Last revision: 2021-12-13  
+Last revision: 2022-09-27
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
 
 ## 2 Organisation and activities
 

--- a/pm/eng/pm_for_mottagningsnamnden.md
+++ b/pm/eng/pm_for_mottagningsnamnden.md
@@ -11,6 +11,10 @@ The purpose of this memo is to regulate the Reception Committee
 Created: 2008-12-11  
 Last revision: 2022-09-27
 
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
+
 ## 2 Organisation
 
 The Reception committee is made up by at least:

--- a/pm/eng/pm_for_naringslivsnamnden.md
+++ b/pm/eng/pm_for_naringslivsnamnden.md
@@ -11,7 +11,11 @@ The purpose of the Business Relations Committee is to market and promote the cha
 ### 1.2 History
 
 Created: 2008-12-11  
-Last revision: 2021-02-25
+Last revision: 2022-09-27
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
 
 ## 2 Organisation and activities
 

--- a/pm/eng/pm_for_qlubbmasteriet_in_sektionen_kista.md
+++ b/pm/eng/pm_for_qlubbmasteriet_in_sektionen_kista.md
@@ -12,7 +12,11 @@ As such QMISK shall arrange parties and other social activities for the chapter 
 ### 1.2 History
 
 Established: 2009-05-15  
-Last revision: 2015-03-02
+Last revision: 2022-09-27
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
 
 ## 2 Organisation
 

--- a/pm/eng/pm_for_sektionens_profil.md
+++ b/pm/eng/pm_for_sektionens_profil.md
@@ -9,7 +9,11 @@ The purpose of this memo is to clearify the guildelines regarding the member's o
 ### 1.2 History
 
 Established: 2014-02-10  
-Last revision: 2014-02-10
+Last revision: 2022-09-27
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
 
 ## 2 Overalls
 

--- a/pm/eng/pm_for_sektionens_styrelse.md
+++ b/pm/eng/pm_for_sektionens_styrelse.md
@@ -11,7 +11,7 @@ The purpose of this Memo is to formulate and to regulate the chapter's Board's c
 Created: 2008-12-11  
 Senast ändrat: 2021-02-25
 
-### 1.3 Revisions to this Memo
+### 1.3 Revising this Memo
 
 In order to pass a revision of this Memo a decision has to be made with a qualified majority on a chapter meeting.
 

--- a/pm/eng/pm_for_sektionens_utrymmen.md
+++ b/pm/eng/pm_for_sektionens_utrymmen.md
@@ -9,7 +9,11 @@ The purpose of this Memo is to regulate the chapter's shared resources, e.g. sto
 ### 1.2 History
 
 Established: 2008-12-11  
-Last revision: 2020-05-20
+Last revision: 2022-09-27
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
 
 ## 2 Rules
 

--- a/pm/eng/pm_for_sektionsfanan.md
+++ b/pm/eng/pm_for_sektionsfanan.md
@@ -9,9 +9,13 @@ This Memo regulates the chapter's standard which is used to represent the chapte
 ### 1.2 History
 
 Established: 2011-12-08  
-Last revision: 2013-02-18
+Last revision: 2022-09-27
 
 The Chapter standard was aquired on 2011-09-21
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
 
 ## 2 Organisation
 

--- a/pm/eng/pm_for_studiemiljonamnden.md
+++ b/pm/eng/pm_for_studiemiljonamnden.md
@@ -11,7 +11,11 @@ Studiemiljönämnden is responsible for ensuring that the chapters members stay 
 ### 1.2 History
 
 Established: 2008-02-05  
-Last revision: 2014-10-07
+Last revision: 2022-09-27
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
 
 ## 2 Organisation
 

--- a/pm/eng/pm_for_studienamnden.md
+++ b/pm/eng/pm_for_studienamnden.md
@@ -9,7 +9,11 @@ This Memo regulates the chapters' education committee which is responsible for c
 ### 1.2 History
 
 Established: 2008-02-05  
-Last revision: 2021-02-25
+Last revision: 2022-09-27
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
 
 ## 2 Organisation
 

--- a/pm/eng/pm_for_traditioner.md
+++ b/pm/eng/pm_for_traditioner.md
@@ -9,16 +9,20 @@ This document regulates the traditions that promotes fellowship and continuity w
 ### 1.2 History
 
 Established: 2014-12-08  
-Last revision: 2014-12-08
+Last revision: 2022-09-27
 
-### 1.3 Conditions
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
+
+### 1.4 Conditions
 
 In order for a tradition to be added to this document it shall take place at least three consecutive years with the same purpouse.  
 A tradition shall be omitted from this document if for one year the coniditons are not met.  
 Such a revision may be made by the chapter board without a desicion from the chapter meeting.  
 Exceptions from this rule may be made in special cases.
 
-### 1.4 Format
+### 1.5 Format
 
 All traditions shall be described with it's name and a short description under the committee that organises and is responsible for the tradition.
 

--- a/pm/eng/pm_for_traditionsmesterit.md
+++ b/pm/eng/pm_for_traditionsmesterit.md
@@ -12,7 +12,11 @@ As such TMEIT shall arrange parties and other social activities for the chapter'
 ### 1.2 History
 
 Established: 2008-02-05  
-Last revision: 2021-02-25
+Last revision: 2022-09-27
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
 
 ## 2 Organisation
 

--- a/pm/eng/pm_for_valberedningen.md
+++ b/pm/eng/pm_for_valberedningen.md
@@ -11,7 +11,11 @@ The Elections Committee shall prepare the elections administered by the chapter 
 ### 1.2. History
 
 Established: 2014-02-10  
-Last revision: 2014-04-09
+Last revision: 2022-09-27
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.
 
 ## 2. Background
 

--- a/pm/swe/pm_for_historieansvarig.md
+++ b/pm/swe/pm_for_historieansvarig.md
@@ -9,7 +9,11 @@ Syftet med detta PM är att reglera sektionens historieansvarige.
 ### 1.2 Historik
 
 Upprättat: 2020-02-25  
-Senast ändrat: 2021-02-25
+Senast ändrat: 2022-09-27
+
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
 
 ## 2 Ansvar
 

--- a/pm/swe/pm_for_idrottsnamnden.md
+++ b/pm/swe/pm_for_idrottsnamnden.md
@@ -11,7 +11,11 @@ Idrottsnämndens syfte är att främja idrottsverksamheten på sektionen.
 ### 1.2 Historik
 
 Upprättat: 2008-12-11  
-Senast ändrat: 2014-10-07
+Senast ändrat: 2022-09-27
+
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
 
 ## 2 Organisation
 

--- a/pm/swe/pm_for_information.md
+++ b/pm/swe/pm_for_information.md
@@ -9,7 +9,11 @@ Denna PM är avsedd att reglera sektionens officiella informationskanaler samt s
 ### 1.2 Historik
 
 Upprättat: 2008-12-11  
-Senast ändrat: 2021-02-25
+Senast ändrat: 2022-09-27
+
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
 
 ## 2 Officiella informationskanaler
 

--- a/pm/swe/pm_for_insignia.md
+++ b/pm/swe/pm_for_insignia.md
@@ -11,7 +11,7 @@ Denna PM är avsedd att reglera sektionens insignia.
 Upprättat: 2013-10-16  
 Senast ändrat: 2021-02-25
 
-## 1.3 Ändring
+### 1.3 Ändrande av PM
 
 För ändring av ändring av denna PM krävs beslut taget med kvalificerad majoritet på två på varandra följande SM.
 

--- a/pm/swe/pm_for_iterativa_klubben.md
+++ b/pm/swe/pm_for_iterativa_klubben.md
@@ -10,7 +10,11 @@ ITerativa Klubben är en nämnd som syftar till att anordna evenemang för sekti
 ### 1.2 Historik
 
 Upprättat: 2008-12-11  
-Senast ändrat: 2021-02-25
+Senast ändrat: 2022-09-27
+
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
 
 ## 2 Organisation
 

--- a/pm/swe/pm_for_kommunikationsnamnden.md
+++ b/pm/swe/pm_for_kommunikationsnamnden.md
@@ -11,7 +11,11 @@ Kommunikationsnämndens syfte är att koordinera kommunikation, informationsflö
 ### 1.2 Historik
 
 Upprättat: 2014-01-01  
-Senast ändrat: 2021-12-13  
+Senast ändrat: 2022-09-27  
+
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
 
 ## 2 Organisation och verksamhet
 

--- a/pm/swe/pm_for_mottagningsnamnden.md
+++ b/pm/swe/pm_for_mottagningsnamnden.md
@@ -11,6 +11,10 @@ Denna PM är avsedd att reglera Mottagningsnämnden.
 Upprättat: 2008-12-11  
 Senast ändrat: 2022-09-27
 
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
+
 ## 2 Organisation
 
 Mottagningsnämnden består som minst av:

--- a/pm/swe/pm_for_naringslivsnamnden.md
+++ b/pm/swe/pm_for_naringslivsnamnden.md
@@ -11,7 +11,11 @@ Näringslivsnämndens syfte är att marknadsföra sektionen samt arbeta för att
 ### 1.2 Historik
 
 Upprättat: 2008-12-11  
-Senast ändrat: 2021-02-25
+Senast ändrat: 2022-09-27
+
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
 
 ## 2 Organisation och verksamhet
 

--- a/pm/swe/pm_for_qlubbmasteriet_in_sektionen_kista.md
+++ b/pm/swe/pm_for_qlubbmasteriet_in_sektionen_kista.md
@@ -12,7 +12,11 @@ Som sådant ska QMISK anordna fester och andra sociala arrangemang för sektione
 ### 1.2 Historik
 
 Upprättat: 2009-05-15  
-Senast ändrat: 2015-03-02
+Senast ändrat: 2022-09-27
+
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
 
 ## 2 Organisation
 

--- a/pm/swe/pm_for_sektionens_profil.md
+++ b/pm/swe/pm_for_sektionens_profil.md
@@ -9,7 +9,11 @@ Syftet med denna PM är att klargöra de riktlinjer som gäller medlemmar i Sekt
 ### 1.2 Historik
 
 Upprättat: 2014-02-10  
-Senast ändrat: 2014-02-10
+Senast ändrat: 2022-09-27
+
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
 
 ## 2 Overaller
 

--- a/pm/swe/pm_for_sektionens_utrymmen.md
+++ b/pm/swe/pm_for_sektionens_utrymmen.md
@@ -9,7 +9,11 @@ Denna PM är avsett att reglera hanteringen av sektionens gemensamma resurser, s
 ### 1.2 Historik
 
 Upprättat: 2008-12-11  
-Senast ändrat: 2020-05-20
+Senast ändrat: 2022-09-27
+
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
 
 ## 2 Regler
 

--- a/pm/swe/pm_for_sektionsfanan.md
+++ b/pm/swe/pm_for_sektionsfanan.md
@@ -9,9 +9,13 @@ Denna PM reglerar sektionens fana vilken används för att representera sektione
 ### 1.2 Historik
 
 Upprättat: 2011-12-08  
-Senast ändrat: 2013-02-18
+Senast ändrat: 2012-09-27
 
 Sektionsfanan införskaffades 2011-09-21
+
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
 
 ## 2 Organisation
 

--- a/pm/swe/pm_for_studiemiljonamnden.md
+++ b/pm/swe/pm_for_studiemiljonamnden.md
@@ -11,7 +11,11 @@ Studiemiljönämnden ansvarar för att sektionens medlemmar vistas i en god stud
 ### 1.2 Historik
 
 Upprättat: 2008-02-05  
-Senast ändrat: 2014-10-07
+Senast ändrat: 2022-09-27
+
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
 
 ## 2 Organisation
 

--- a/pm/swe/pm_for_studienamnden.md
+++ b/pm/swe/pm_for_studienamnden.md
@@ -9,7 +9,11 @@ Denna PM reglerar sektionens studienämnd vilken ansvarar för samordning av stu
 ### 1.2 Historik
 
 Upprättat: 2008-02-05  
-Senast ändrat: 2021-02-25
+Senast ändrat: 2022-09-27
+
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
 
 ## 2 Organisation
 

--- a/pm/swe/pm_for_traditioner.md
+++ b/pm/swe/pm_for_traditioner.md
@@ -9,16 +9,20 @@ Detta dokument reglerar traditioner som är bra för sektionens sammanhållning 
 ### 1.2 Historik
 
 Upprättat: 2014-12-08  
-Senast ändrat: 2014-12-08
+Senast ändrat: 2022-09-27
 
-### 1.3 Villkor
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
+
+### 1.4 Villkor
 
 För att en tradition ska läggas till i detta dokument ska den ha ägt rum minst tre år i rad och med samma ändamål.  
 En tradition skall strykas ur detta dokument om villkoren inte uppfylls ett år.  
 En sådan ändring kan göras av styrelsen utan beslut fattat av sektionsmötet.  
 Undantag från denna regel kan göras i särskilda fall.
 
-### 1.4 Format
+### 1.5 Format
 
 Alla traditioner ska beskrivas med ett namn och en kortare beskrivning, och ska vara skrivet under den nämnd som arrangerar och ansvarar för traditionen.
 

--- a/pm/swe/pm_for_traditionsmesterit.md
+++ b/pm/swe/pm_for_traditionsmesterit.md
@@ -12,7 +12,11 @@ Som sådant ska TMEIT anordna fester och andra sociala arrangemang för sektione
 ### 1.2 Historik
 
 Upprättat: 2008-02-05  
-Senast ändrat: 2014-10-07
+Senast ändrat: 2022-09-27
+
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
 
 ## 2 Organisation
 

--- a/pm/swe/pm_for_valberedningen.md
+++ b/pm/swe/pm_for_valberedningen.md
@@ -11,7 +11,11 @@ Valberedningen bereder de val som förrättas av sektionsmötet i enlighet med s
 ### 1.2. Historik
 
 Upprättat: 2014-02-10  
-Senast ändrat: 2014-04-09
+Senast ändrat: 2022-09-27
+
+### 1.3 Ändrande av PM
+
+För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
 
 ## 2. Bakgrund
 


### PR DESCRIPTION
The majority of the Memos are missing the point §1.3 Revising this Memo. It is stated in Memo for Memo that it should exist. Therefore, the point is added to the following Memos.

[Proposition for Memo without point 1.3](https://docs.google.com/document/d/1k-6qNr0NoHlrEZpXjOaAas7BFGNhCbSSRpM_agCoTQ4/edit)
[SM#3 Protocol](https://drive.google.com/file/d/1za-oFJUo3p4fkMUSdlIrFmRuf930DCya/view)

Full Details:

- §1.3 “Conditions” is moved to §1.4 and §1.4 “Format” is moved to §1.5 in “Memo for Traditions”.
- §1.3 “Revising this Memo” with the text “In order to pass a revision of this Memo, a decision has to be made with a qualified majority at a chapter meeting.” is added to the following Memos:
  - Memo for Graphical Profile
  - Memo for History Responsible
  - Memo for the Sports Committee
  - Memo for Information
  - Memo for ITerativa Klubben
  - Memo for the Communication Committee
  - Memo for the Reception Committee
  - Memo for the Business Relations Committee
  - Memo for Qlubbmästeriet IN-sektionen Kista
  - Memo for the Chapter's Profile
  - Memo for the Chapters Locales
  - Memo for the Chapter Standard
  - Memo for the Study Environment Committee
  - Memo for the Education Committee
  - Memo for Traditions
  - Memo for TraditionsMEsterIT
  - Memo for the Elections Committee

Minor fixes to the markup and spelling were made to some Memos point §1.3.
