### PR TITLE
Add masters reception responsible (MÅNGA) and minor revisions - SM#3 2022 - 2022-09-27

### DIFF
--- a/pm/eng/00_pm_for_pm.md
+++ b/pm/eng/00_pm_for_pm.md
@@ -71,7 +71,7 @@ Memo for Information, 2008-12-11
 Memo for Insignia, 2013-10-16  
 Memo for PIFF and PUFF, 2020-09-28
 Memo for Qlubbmästeriet IN-Sektionen Kista, 2009-05-15  
-Memo for Reception Committee, 2008-12-11  
+Memo for Reception Committee, 2022-09-27  
 Memo for Sports Committee, 2008-12-11  
 Memo for Stickkontaktsansvarig, 2019-02-23  
 Memo for Student Social Committee, 2020-05-20  
@@ -85,5 +85,4 @@ Memo for the Chapter Standard, 2011-12-08
 Memo for the Chapter's Locals, 2008-12-11  
 Memo for the Chapter's Profile, 2014-02-10  
 Memo for the Elections Committee, 2014-02-10  
-Memo for the Safety Officer, 2014-09-22  
-
+Memo for the Safety Officer, 2014-09-22

--- a/pm/eng/pm_for_fortroendevalda_positioner.md
+++ b/pm/eng/pm_for_fortroendevalda_positioner.md
@@ -27,39 +27,39 @@ The list may be changed without decisions at SM, where after SM decides on chang
 
 #### 2.2.1 Chapter Board
 
--   Chapter President
--   Chapter vice President
--   Chapter Secretary
--   Chapter Cashier
--   Board member responsible for education influence
--   Board member responsible for student social activities
--   Board member responsible for business relations
--   Board member responsible for communication
--   Board member – two
--   Chapter vice Cashier
+- Chapter President
+- Chapter vice President
+- Chapter Secretary
+- Chapter Cashier
+- Board member responsible for education influence
+- Board member responsible for student social activities
+- Board member responsible for business relations
+- Board member responsible for communication
+- Board member – two
+- Chapter vice Cashier
 
 #### 2.2.2 Studiemiljönämnden
 
--   StURe
--   Lill-StURe
+- StURe
+- Lill-StURe
 
 #### 2.2.3 Studiesocialanämnden
 
--   vice President with responsibility for JML
+- vice President with responsibility for JML
 
 #### 2.2.4 Studienämnden
 
--   PAS CINTE
--   PAS TCOMK
--   PAS TIDAB
--   PAS TIEDB
--   PAS Master
+- PAS CINTE
+- PAS TCOMK
+- PAS TIDAB
+- PAS TIEDB
+- PAS Master
 
 #### 2.2.5 Näringslivsnämnden
 
 - vice President
 - Responsible for Kista Arbetsmarknadsdag (KAM)
- 
+
 #### 2.2.6 Kommunikationsnämnden
 
 - vice President
@@ -73,6 +73,7 @@ The list may be changed without decisions at SM, where after SM decides on chang
 
 - INGEN
 - NÅGON
+- MÅNGA
 - Member - three
 
 #### 2.2.9 PIFF och PUFF

--- a/pm/eng/pm_for_mottagningsnamnden.md
+++ b/pm/eng/pm_for_mottagningsnamnden.md
@@ -9,20 +9,25 @@ The purpose of this memo is to regulate the Reception Committee
 ### 1.2 History
 
 Created: 2008-12-11  
-Last revision: 2019-05-21
+Last revision: 2022-09-27
 
 ## 2 Organisation
 
 The Reception committee is made up by at least:
 
--   Chairperson and main responsible, called INitiationsGENeral (INGEN), who has the main responsibility and final say regarding the Reception.  
-    INGEN is elected by the chapter meeting.
--   Deputy chairperson. Shall in the absence of INGEN carry out INGEN's duties and execute INGEN's responsibilities.  
-    Is responsible for the economy and contact for the chapter's treasurer.  
-    The vice chairperson is also responsible for the work delegated to them by INGEN by mutual agreement.  
-    Is elected by the chapter meeting.
--   Three board members. Their areas of responsibilitiy is decided by the Reception committee.  
-    They are elected by the chapter meeting.
+- Chairperson and main responsible, called INitiationsGENeral (INGEN), who has the main responsibility and final say regarding the Reception.  
+  INGEN is elected by the chapter meeting.
+- Deputy chairperson.
+  Shall in the absence of INGEN carry out INGEN's duties and execute INGEN's responsibilities.  
+  Is responsible for the economy and contact for the chapter's treasurer.  
+  The vice chairperson is also responsible for the work delegated to them by INGEN by mutual agreement.  
+  Called Neurotisk Åskådare till Generalens Oundvikliga Nederlag (NÅGON).
+  Is elected by the chapter meeting.
+- Masters reception responsible, who has the main responsibility and the final say regarding the masters reception together with INGEN.
+  Called Mastermottagningens Ångestfulla och Neurotiska Generellt Ansvarige (MÅNGA).
+  Is elected by the chapter meeting.
+- Three board members. Their areas of responsibilitiy is decided by the Reception committee.  
+  They are elected by the chapter meeting.
 
 The Reception's management/leadership, regulated by the Reception's rules, are themselves responsible for creating the structure within the committee.  
 In addition to this the Reception committee may freely define and assign additional areas of responsibility to handle questions such as specific events and marketing.
@@ -31,7 +36,7 @@ The Reception committee shall actively seek to include the chapter's other commi
 
 The chairperson is responsible to report to the board member responsible for studysocial activities before the chapter board's meetings during the whole business year.
 
-The chairperson and deputy chairperson are elected on the first ordinary chapter meeting following the end of the reception.
+The chairperson, deputy chairperson and masters reception responsible are elected on the first ordinary chapter meeting following the end of the reception.
 
 ## 3 Economy
 
@@ -47,4 +52,8 @@ It is the responsibility of the committee to make certain that the execution of 
 
 For more extensive information please refer to the Rules for the Reception committee.
 
-The operational year of the Reception committee starts when all members of the committee's board have been elected by the chapter meeting.
+The operational year of the Reception committee starts when all members of the committee's board have been elected by the chapter meeting or the chapters operational year starts, whichever occurs first.
+
+### 4.1 Masters reception
+
+The Reception committee shall formulate, plan and execute events for the new masters students at KTH in Kista.

--- a/pm/swe/00_pm_for_pm.md
+++ b/pm/swe/00_pm_for_pm.md
@@ -70,7 +70,7 @@ PM för Idrottsnämnden, 2008-12-11
 PM för Information, 2008-12-11  
 PM för Insignia, 2013-10-16  
 PM för Kommunikationsnämnden, 2014-01-01  
-PM för Mottagningsnämnden, 2008-12-11  
+PM för Mottagningsnämnden, 2022-09-27  
 PM för Näringslivsnämnden, 2008-12-11  
 PM för PIFF och PUFF, 2020-09-28  
 PM för Qlubbmästeriet IN-sektionen Kista, 2009-05-15  
@@ -85,4 +85,4 @@ PM för Studienämnden, 2008-12-11
 PM för Studiesociala nämnden, 2020-05-20  
 PM för Traditioner, 2014-12-08  
 PM för TraditionsMEsterIT, 2008-12-11  
-PM för Valberedningen, 2014-02-10  
+PM för Valberedningen, 2014-02-10

--- a/pm/swe/pm_for_fortroendevalda_positioner.md
+++ b/pm/swe/pm_for_fortroendevalda_positioner.md
@@ -74,6 +74,7 @@ Listan får ändras utan att beslut behöver fattas på SM, var efter SM besluta
 
 - INGEN
 - NÅGON
+- MÅNGA
 - Ledamot - tre
 
 #### 2.2.9 PIFF och PUFF

--- a/pm/swe/pm_for_mottagningsnamnden.md
+++ b/pm/swe/pm_for_mottagningsnamnden.md
@@ -9,22 +9,25 @@ Denna PM är avsedd att reglera Mottagningsnämnden.
 ### 1.2 Historik
 
 Upprättat: 2008-12-11  
-Senast ändrat: 2019-05-21
+Senast ändrat: 2022-09-27
 
 ## 2 Organisation
 
 Mottagningsnämnden består som minst av:
 
--   Ordförande och huvudansvarig, benämnd INitiationsGENeral (INGEN), som har det yttersta ansvaret och ordet avseende Mottagningen som helhet.  
-    Väljs av SM.
--   Vice ordförande.  
-    Ska i INGENs frånvaro utöva dennes befogenheter, och fullgöra dennes plikter.  
-    Är ekonomisk samordnare och fungerar som kontaktperson med sektionens kassör.  
-    Utöver detta innehar vice ordförande det ansvar som fördelas mellan denne och ordförande efter gemensam överenskommelse.  
-    Väljs av SM.
--   Tre ledamöter i Mottagningsnämndens styrelse.  
-    Deras ansvarsområden bestäms av mottagningsnämnden i början av verksamhetsåret.  
-    De väljs av SM.
+- Ordförande och huvudansvarig, benämnd INitiationsGENeral (INGEN), som har det yttersta ansvaret och ordet avseende Mottagningen som helhet.  
+  Väljs av SM.
+- Vice ordförande.  
+  Ska i INGENs frånvaro utöva dennes befogenheter, och fullgöra dennes plikter.  
+  Är ekonomisk samordnare och fungerar som kontaktperson med sektionens kassör.  
+  Utöver detta innehar vice ordförande det ansvar som fördelas mellan denne och ordförande efter gemensam överenskommelse.  
+  Benämnd Neurotisk Åskådare till Generalens Ounvikliga Nederlag (NÅGON).
+  Väljs av SM.
+- Mastermottagningens ansvaige, som har yttersta ansvaret för- och ordet avseende mastermottagningen tillsammans med INGEN.
+  Benämnd Mastermottagningens Ångestfulla och Neurotiska Generellt Ansvarige (MÅNGA).
+  Väljs av SM.
+- Tre ledamöter i Mottagningsnämndens styrelse. Deras ansvarsområden bestäms av mottagningsnämnden i början av verksamhetsåret.  
+  De väljs av SM.
 
 Mottagningens ledning, reglerat av Mottagningens reglemente, bygger själva upp strukturen inom nämnden.  
 Utöver detta står det Mottagningsnämnden fritt att internt definiera och tilldela ytterligare ansvarsposter för att hantera frågor såsom exempelvis evenemangsansvar och marknadsföring.
@@ -33,7 +36,7 @@ Mottagningsnämnden ska aktivt verka för att inkludera övriga nämnder i sina 
 
 Mottagningsansvarig åläggs att rapportera till ledamot med ansvar för studiesocial verksamhet i samband med sektionens styrelsemöten under hela verksamhetsåret.
 
-Val av Ordförande och Vice ordförande skall ske på första ordinarie Sektionsmöte efter Mottagningens avslutande.
+Val av Ordförande, Vice ordförande och Mastermottagningens ansvarige skall ske på första ordinarie Sektionsmöte efter Mottagningens avslutande.
 
 ## 3 Ekonomi
 
@@ -49,4 +52,8 @@ Det är nämndens ansvar att tillse att Mottagningen i sitt utförande inte stri
 
 För utförligare information se Reglemente för Mottagningsnämnden.
 
-Verksamhetsåret för Mottagningsnämnden börjar då hela mottagningsstyrelsen för nästkommande år valts av SM.
+Verksamhetsåret för Mottagningsnämnden börjar då hela mottagningsstyrelsen för nästkommande år valts av SM eller sektionens verksamhetsår börjar, vilket som än sker först.
+
+### 4.1 Mastermottagningen
+
+Mottagningsnämnden skall utarbeta, planera och genomföra evenemang för nyantagna masterstudenter vid KTH i Kista.


### PR DESCRIPTION
Detailed changes:
- Added masters reception responsible to reception board as separate board member.
- Added `4.1 Masters reception` describing the activities (and responsibilities) of the masters reception.
- Added the name of the deputy chair (NÅGON) to the document.
- Updated text regarding start of the operational year to add a clause forcing the new year to start at the latest when the chapters operational year starts.
- Updated `00_pm_for_pm` and `pm_for_fortroendevalda_positioner` accordingAdd masters reception responsible (MÅNGA) and minor revisions

**[Motion:](https://docs.google.com/document/d/1dCEUaFo5ZHx_18aEC2qt8icx_Ax7Qobrn7rmUB9Q62Q/edit?usp=sharing)**
- Adds master reception responsible to the reception board as a separate elected position and outlines the work that should be done to provide new masters students with a reception (masters reception).
- Adds the name `NÅGON` to the description of the deputy chairperson of the reception
- Adds a clause to the paragraph describing the start of the reception committees operational year to guarantee that it starts at the latest when the chapter's starts.