### PR TITLE
Removal of The Link - SM#3 2022 - 2022-09-27

### DIFF
--- a/pm/eng/pm_for_fortroendevalda_positioner.md
+++ b/pm/eng/pm_for_fortroendevalda_positioner.md
@@ -9,7 +9,7 @@ The purpose of this Memo is to list all of the chapter's trustee elected positio
 ### 1.2 History
 
 Created: 2021-11-29  
-Last revision: 2021-11-29
+Last revision: 2022-09-27
 
 ### 1.3 Revising this Memo
 

--- a/pm/eng/pm_for_fortroendevalda_positioner.md
+++ b/pm/eng/pm_for_fortroendevalda_positioner.md
@@ -97,17 +97,12 @@ The list may be changed without decisions at SM, where after SM decides on chang
 - Root
 - Sudo
 
-#### 2.2.13 The Link
-
-- President
-- vice President
-
-#### 2.2.14 The Elections Committee
+#### 2.2.13 The Elections Committee
 
 - Convener
 - Member - at least 4
 
-#### 2.2.15 Andra Positioner
+#### 2.2.14 Andra Positioner
 
 - Auditor - two
 - Safety officer

--- a/pm/swe/pm_for_fortroendevalda_positioner.md
+++ b/pm/swe/pm_for_fortroendevalda_positioner.md
@@ -10,7 +10,7 @@ Denna PM är avsedd till att lista alla sektionens förtroendevalda positioner.
 
 Upprättat: 2021-11-29
 
-Senast ändrat: 2021-11-29
+Senast ändrat: 2022-09-27
 
 ### 1.3 Ändrande av PM
 

--- a/pm/swe/pm_for_fortroendevalda_positioner.md
+++ b/pm/swe/pm_for_fortroendevalda_positioner.md
@@ -98,17 +98,12 @@ Listan får ändras utan att beslut behöver fattas på SM, var efter SM besluta
 - Root
 - Sudo
 
-#### 2.2.13 The Link
-
-- Ordförande
-- vice Ordförande
-
-#### 2.2.14 Valberedningen
+#### 2.2.13 Valberedningen
 
 - Sammankallande
 - Medlem - minst 4
 
-#### 2.2.15 Andra Positioner
+#### 2.2.14 Andra Positioner
 
 - Revisor - två
 - Skyddsvårdsombud


### PR DESCRIPTION
Removes The Link from Trustee Elected Positions since the committee is entirely removed.

[Proposition to abolish “Memo for The Link”](https://docs.google.com/document/d/1zpvD-YhWBDkAAYDoK3aQsGXGA7FbF9R6ncBUnDWpmck/edit)
[SM#3 Protocol](https://drive.google.com/file/d/1za-oFJUo3p4fkMUSdlIrFmRuf930DCya/view)

Note: The Memo for The Link was never made fully official which is why it has not been added to this repository before and therefore can't be removed from here with this PR.