### PR TITLE
Introduction of PM for Purchase Coordinator

### DIFF
--- a/pm/eng/00_pm_for_pm.md
+++ b/pm/eng/00_pm_for_pm.md
@@ -71,6 +71,7 @@ Memo for ITerativa Klubben, 2008-12-11
 Memo for Information, 2008-12-11  
 Memo for Insignia, 2013-10-16  
 Memo for PIFF and PUFF, 2020-09-28
+Memo for Purchase Coordinator, 2022-12-XX  
 Memo for Qlubbmästeriet IN-Sektionen Kista, 2009-05-15  
 Memo for Reception Committee, 2022-09-27  
 Memo for Sports Committee, 2008-12-11  

--- a/pm/eng/pm_for_fortroendevalda_positioner.md
+++ b/pm/eng/pm_for_fortroendevalda_positioner.md
@@ -30,13 +30,13 @@ The list may be changed without decisions at SM, where after SM decides on chang
 - Chapter President
 - Chapter vice President
 - Chapter Secretary
-- Chapter Cashier
+- Chapter Treasurer
 - Board member responsible for education influence
 - Board member responsible for student social activities
 - Board member responsible for business relations
 - Board member responsible for communication
 - Board member – two
-- Chapter vice Cashier
+- Chapter vice Treasurer
 
 #### 2.2.2 Studiemiljönämnden
 
@@ -110,3 +110,4 @@ The list may be changed without decisions at SM, where after SM decides on chang
 - Standard bearer
 - vice Standard bearer
 - Stickkontaktsansvarig
+- Purchase Coordinator

--- a/pm/eng/pm_for_inkopssamordnare
+++ b/pm/eng/pm_for_inkopssamordnare
@@ -1,0 +1,52 @@
+# Memo for Memos
+
+## 1 Formalities
+
+### 1.1 Purpose
+
+The purpose of this Memo is to regulate the chapter’s purchase coordinator.
+
+### 1.2 History
+
+Created: 2022-12-XX  
+Last revision: 2022-12-XX
+
+### 1.3 Revising this Memo
+
+In order to pass a revision of this Memo, a decision has to be made with a qualified majority on a chapter meeting.
+
+## 2 Responsbilities
+
+### 2.1 Purchases
+
+The purchasing coordinator is responsible for and shall
+- have an overview that all the chapter’s purchases are done correctly.
+- coordinate the purchase of consumables for the chapter.
+- ensure that the chapter has a wide and varied basic range of drinks.
+
+### 2.2 Pricing
+
+The purchasing coordinator is responsible for ensuring that everything sold within the chapter is done in a legal and chapter-supporting manner.
+
+All pricing must be done where the chapter makes a profit on everything sold.
+Where the cheapest alcoholic option is never cheaper than the corresponding non-alcoholic option.
+
+### 2.3 Budget
+
+The purchasing coordinator are responsible for ensuring that the chapter’s purchases follow the set budget and are closely aware if it changes.
+
+## 3 Organisation
+
+The purchasing coordinator must cooperate with the chapter’s cashier and is an intermediary with the committee's purchasing responsible.
+
+## 4 Regulations
+
+### 4.1 Appoint
+
+The purchasing coordinator may not be elected board members, trustee elected committee members or responsible for purchasing in any committee.
+
+### 4.2 Education
+
+The purchasing coordinator must have completed the STAD-education.
+
+In order to be elected, the purchasing coordinator does not need to have completed the STAD-education, but must attend the training at the next opportunity, where it has priority.

--- a/pm/eng/pm_for_sektionens_styrelse.md
+++ b/pm/eng/pm_for_sektionens_styrelse.md
@@ -96,6 +96,8 @@ The deputy treasurer shall share the treasures duties and responsibilities and s
 
 The treasurer shall actively cooperate with and attend meetings arranged by THS Economy council.
 
+The treasurer shall actively collaborate with the chapter’s purchasing coordinator and keep them up to date with the chapter’s finances and ensure that it follows the section's budget.
+
 #### 3.2.5 Board member responsible for education influence
 
 The Board member responsible for education influence shall work long-term and strategically with educational, equality, and diversity questions within the programs connected to the chapter and shall work towards their constant improvement until their best possible state is achieved.  

--- a/pm/swe/00_pm_for_pm.md
+++ b/pm/swe/00_pm_for_pm.md
@@ -68,6 +68,7 @@ PM för Historieansvarig, 2021-02-25
 PM för ITerativa Klubben, 2008-12-11  
 PM för Idrottsnämnden, 2008-12-11  
 PM för Information, 2008-12-11  
+PM för Inköpssamordnare, 2022-12-XX  
 PM för Insignia, 2013-10-16  
 PM för Kommunikationsnämnden, 2014-01-01  
 PM för Mottagningsnämnden, 2022-09-27  

--- a/pm/swe/pm_for_fortroendevalda_positioner.md
+++ b/pm/swe/pm_for_fortroendevalda_positioner.md
@@ -111,3 +111,4 @@ Listan får ändras utan att beslut behöver fattas på SM, var efter SM besluta
 - Fanbärare
 - vice Fanbärare
 - Stickkontaktsansvarig
+- Inköpssamordnare

--- a/pm/swe/pm_for_inkopssamordnare
+++ b/pm/swe/pm_for_inkopssamordnare
@@ -1,0 +1,52 @@
+# PM för Inköpssamordnare
+
+## 1 Formalia
+
+### 1.1 Syfte
+
+Syftet med detta PM är att reglera sektionens inköpssamordnare.
+
+### 1.2 Historik
+
+Upprättat: 2022-12-XX  
+Senast ändrat: 2022-12-XX
+
+### 1.3 Ändrande av PM
+
+För ändrande av denna PM krävs ett beslut taget med kvalificerad majoritet på ett SM.
+
+## 2 Ansvar
+
+### 2.1 Inköp
+
+Inköpssamordnaren ansvarar för och skall
+- ha en överblick över att alla sektionens inköp sker på ett korrekt sätt.
+- samordna inköp av förbrukningsmaterial till sektionen.
+- se till att sektionen har ett brett och varierat basutbud på dryck.
+
+### 2.2 Prissättning
+
+Inköpssamordnaren ansvarar för att allt som säljs inom sektionen görs på ett lagligt och sektionsfrämjande sätt.
+
+All prissättning skall göras där sektionen går i vinst på allt som säljs.
+Där det billigaste alkoholhaltiga alternativet aldrig är billigare än det motsvarande alkoholfria alternativet.
+
+### 2.3 Budget
+
+Inköpssamordnaren har som ansvar att sektionens inköp följer den satta budgeten och är nära insatt ifall den ändras. 
+
+## 3 Organisation
+
+Inköpssamordnaren skall samarbeta med sektionens kassör och är en mellanhand mot nämndernas inköpsansvariga.
+
+## 4 Regleringar
+
+### 4.1 Tillsättning
+
+Inköpssamordnaren får inte vara förtroendevalda styrelsemedlemmar, förtroendevalda nämndmedlemmar eller ansvariga för inköp i någon nämnd.
+
+### 4.2 Utbildning
+
+Inköpssamordnaren skall ha gått STAD-utbildningen.
+
+För att bli vald behöver inköpssamordnaren inte ha gått STAD-utbildningen, men måste gå utbildningen vid första nästkommande tillfälle, där den har företräde.

--- a/pm/swe/pm_for_sektionens_styrelse.md
+++ b/pm/swe/pm_for_sektionens_styrelse.md
@@ -96,6 +96,8 @@ Vice kassör delar kassörens förpliktelser och ansvar, och skall på samma sä
 
 Kassören ska aktivt samarbeta med och delta i möten anordnat av THS Ekonomiråd.
 
+Kassören skall aktivt samarbeta med sektionens inköpssamordnare och hålla den uppdaterad med sektionens ekonomi samt se till att den följer sektionens budget.
+
 #### 3.2.5 Ledamot med ansvar för utbildningspåverkan
 
 Styrelseledamot med ansvar för utbildningspåverkan ska arbeta långsiktigt och strategiskt med utbildnings-, jämlikhets- och mångfaldsfrågor inom de program som finns inom sektionen och verka för att de ständigt förbättras intill det bästa är uppnått.  


### PR DESCRIPTION
Adds a new Memo for Purchase Coordinator role, responsible for all the purchases done within the chapter.

[Proposition for Purchase Coordinator](https://docs.google.com/document/d/1knOVz3RhjgZoGCBz2JKm-qFYEN23C3e5xIHV-DGlf94/view)

Minor editorial change to rename cashier to treasurer to keep consistency between pm and statues.