### PR TITLE
Add QMISK, TMEIT, ITK Reception Budget responsible to be approved - SM#5 2023 - 2023-12-05

### DIFF
--- a/pm/eng/pm_for_fortroendevalda_positioner.md
+++ b/pm/eng/pm_for_fortroendevalda_positioner.md
@@ -71,7 +71,8 @@ The list may be changed without decisions at SM, where after SM decides on chang
 - INGEN
 - NÅGON
 - MÅNGA
-- Member - three
+- Member responsible for Budget
+- Member - two
 
 #### 2.2.8 PIFF och PUFF
 

--- a/pm/eng/pm_for_fortroendevalda_positioner.md
+++ b/pm/eng/pm_for_fortroendevalda_positioner.md
@@ -83,16 +83,19 @@ The list may be changed without decisions at SM, where after SM decides on chang
 
 - TranditionsMästare
 - vice TraditionsMästare
+- Skattmästare
 
 #### 2.2.10 QMISK
 
 - QlubbMästare
 - vice QlubbMästare
+- Skattmästare
 
 #### 2.2.11 ITK
 
 - Root
 - Sudo
+- Bureaucracy Senator
 
 #### 2.2.12 The Elections Committee
 

--- a/pm/eng/pm_for_iterativa_klubben.md
+++ b/pm/eng/pm_for_iterativa_klubben.md
@@ -18,9 +18,11 @@ In order to pass a revision of this Memo, a decision has to be made with a quali
 
 ## 2 Organisation
 
-The ITerative Club is led by the committee's chairperson, known as root, and a deputy chairperson, known as sudo, they are both responsible for the committee's activities.
-
+The ITerative Club is led by the committee's chairperson, known as root, and a deputy chairperson, known as sudo, they are both responsible for the committee's activities.  
 They are approved by the chapter meeting.
+
+ITerative Club's budget is managed by Bureaucracy Senator.  
+Approved by the chapter meeting.
 
 Other committee board members are elected according to the committee's regulations.  
 

--- a/pm/eng/pm_for_iterativa_klubben.md
+++ b/pm/eng/pm_for_iterativa_klubben.md
@@ -21,7 +21,7 @@ In order to pass a revision of this Memo, a decision has to be made with a quali
 The ITerative Club is led by the committee's chairperson, known as root, and a deputy chairperson, known as sudo, they are both responsible for the committee's activities.  
 They are approved by the chapter meeting.
 
-ITerative Club's budget is managed by Bureaucracy Senator.  
+ITerative Club's budget is managed by the Bureaucracy Senator.  
 Approved by the chapter meeting.
 
 Other committee board members are elected according to the committee's regulations.  

--- a/pm/eng/pm_for_mottagningsnamnden.md
+++ b/pm/eng/pm_for_mottagningsnamnden.md
@@ -53,7 +53,7 @@ Is responsible for the economy and contact for the chapter's treasurer.
 Shall manage the reception budget.
 
 ### 2.5 Board Member
-Areas of responsibilitiy is decided by the Reception committee.
+Their areas of responsibilitiy is decided by the Reception committee.
 
 ## 3 Economy
 

--- a/pm/eng/pm_for_mottagningsnamnden.md
+++ b/pm/eng/pm_for_mottagningsnamnden.md
@@ -25,6 +25,8 @@ The Reception committee is made up by at least:
 - Board member responsible for Budget
 - Two board members
 
+They are elected by the chapter meeting
+
 The Reception's management/leadership, regulated by the Reception's rules, are themselves responsible for creating the structure within the committee.  
 In addition to this the Reception committee may freely define and assign additional areas of responsibility to handle questions such as specific events and marketing.
 

--- a/pm/eng/pm_for_mottagningsnamnden.md
+++ b/pm/eng/pm_for_mottagningsnamnden.md
@@ -19,19 +19,11 @@ In order to pass a revision of this Memo, a decision has to be made with a quali
 
 The Reception committee is made up by at least:
 
-- Chairperson and main responsible, called INitiationsGENeral (INGEN), who has the main responsibility and final say regarding the Reception.  
-  INGEN is elected by the chapter meeting.
-- Deputy chairperson.
-  Shall in the absence of INGEN carry out INGEN's duties and execute INGEN's responsibilities.  
-  Is responsible for the economy and contact for the chapter's treasurer.  
-  The vice chairperson is also responsible for the work delegated to them by INGEN by mutual agreement.  
-  Called Neurotisk Åskådare till Generalens Oundvikliga Nederlag (NÅGON).
-  Is elected by the chapter meeting.
-- Masters reception responsible, who has the main responsibility and the final say regarding the masters reception together with INGEN.
-  Called Mastermottagningens Ångestfulla och Neurotiska Generellt Ansvarige (MÅNGA).
-  Is elected by the chapter meeting.
-- Three board members. Their areas of responsibilitiy is decided by the Reception committee.  
-  They are elected by the chapter meeting.
+- President and main responsible (INGEN)
+- vice President (NÅGON)
+- Masters reception responsible (MÅNGA)
+- Board member responsible for Budget
+- Two board members
 
 The Reception's management/leadership, regulated by the Reception's rules, are themselves responsible for creating the structure within the committee.  
 In addition to this the Reception committee may freely define and assign additional areas of responsibility to handle questions such as specific events and marketing.
@@ -41,6 +33,25 @@ The Reception committee shall actively seek to include the chapter's other commi
 The chairperson is responsible to report to the board member responsible for studysocial activities before the chapter board's meetings during the whole business year.
 
 The chairperson, deputy chairperson and masters reception responsible are elected on the first ordinary chapter meeting following the end of the reception.
+
+### 2.1 President and main responsible (INGEN)
+Called INitiationsGENeral (INGEN), who has the main responsibility and final say regarding the Reception.
+
+### 2.2 vice President (NÅGON)
+Shall in the absence of INGEN carry out INGEN's duties and execute INGEN's responsibilities.
+The vice chairperson is also responsible for the work delegated to them by INGEN by mutual agreement.
+Called Neurotisk Åskådare till Generalens Oundvikliga Nederlag (NÅGON).
+
+### 2.3 Masters reception responsible (MÅNGA)
+Has the main responsibility and the final say regarding the masters reception together with INGEN.
+Called Mastermottagningens Ångestfulla och Neurotiska Generellt Ansvarige (MÅNGA).
+
+### 2.4 Board Member responsible for Budget
+Is responsible for the economy and contact for the chapter's treasurer.
+Shall manage the reception budget.
+
+### 2.5 Board Member
+Areas of responsibilitiy is decided by the Reception committee.
 
 ## 3 Economy
 

--- a/pm/eng/pm_for_qlubbmasteriet_in_sektionen_kista.md
+++ b/pm/eng/pm_for_qlubbmasteriet_in_sektionen_kista.md
@@ -20,8 +20,11 @@ In order to pass a revision of this Memo, a decision has to be made with a quali
 
 ## 2 Organisation
 
-QMISK is led by a Qlubbmästare and deputy Qlubbmästare that are responsible for managing the committee.  
+QMISK is led by a Qlubbmästare and vice Qlubbmästare that are responsible for managing the committee.  
 These positions are approved by the chapter meeting.
+
+QMISK's budget is managed by Skattmästare.
+Approved by the chapter meeting.
 
 Other committee members are elected according to QMISK's regulations.
 

--- a/pm/eng/pm_for_qlubbmasteriet_in_sektionen_kista.md
+++ b/pm/eng/pm_for_qlubbmasteriet_in_sektionen_kista.md
@@ -23,7 +23,7 @@ In order to pass a revision of this Memo, a decision has to be made with a quali
 QMISK is led by a Qlubbmästare and vice Qlubbmästare that are responsible for managing the committee.  
 These positions are approved by the chapter meeting.
 
-QMISK's budget is managed by Skattmästare.  
+QMISK's budget is managed by the Skattmästare.  
 Approved by the chapter meeting.
 
 Other committee members are elected according to QMISK's regulations.

--- a/pm/eng/pm_for_qlubbmasteriet_in_sektionen_kista.md
+++ b/pm/eng/pm_for_qlubbmasteriet_in_sektionen_kista.md
@@ -23,7 +23,7 @@ In order to pass a revision of this Memo, a decision has to be made with a quali
 QMISK is led by a Qlubbmästare and vice Qlubbmästare that are responsible for managing the committee.  
 These positions are approved by the chapter meeting.
 
-QMISK's budget is managed by Skattmästare.
+QMISK's budget is managed by Skattmästare.  
 Approved by the chapter meeting.
 
 Other committee members are elected according to QMISK's regulations.

--- a/pm/eng/pm_for_traditionsmesterit.md
+++ b/pm/eng/pm_for_traditionsmesterit.md
@@ -20,10 +20,13 @@ In order to pass a revision of this Memo, a decision has to be made with a quali
 
 ## 2 Organisation
 
-TMEIT is led by the Traditionsmästare.  
-Among the other members a deputy Traditionsmästare is elected to help the Traditionsmästare and in their absence complete their duties.
+TMEIT is led by a Traditionsmästaren and vice Traditionsmästare that are responsible for managing the committee.  
+These positions are approved by the chapter meeting.
 
-These two are approved by the Chapter meeting.
+TMEIT's budget is managed by Skattmästare.
+Approved by the chapter meeting.
+
+Other committee members are elected according to TMEIT's regulations.
 
 ## 3 Activities
 

--- a/pm/eng/pm_for_traditionsmesterit.md
+++ b/pm/eng/pm_for_traditionsmesterit.md
@@ -23,7 +23,7 @@ In order to pass a revision of this Memo, a decision has to be made with a quali
 TMEIT is led by a Traditionsmästaren and vice Traditionsmästare that are responsible for managing the committee.  
 These positions are approved by the chapter meeting.
 
-TMEIT's budget is managed by Skattmästare.
+TMEIT's budget is managed by Skattmästare.  
 Approved by the chapter meeting.
 
 Other committee members are elected according to TMEIT's regulations.

--- a/pm/eng/pm_for_traditionsmesterit.md
+++ b/pm/eng/pm_for_traditionsmesterit.md
@@ -23,7 +23,7 @@ In order to pass a revision of this Memo, a decision has to be made with a quali
 TMEIT is led by a Traditionsmästaren and vice Traditionsmästare that are responsible for managing the committee.  
 These positions are approved by the chapter meeting.
 
-TMEIT's budget is managed by Skattmästare.  
+TMEIT's budget is managed by the Skattmästare.  
 Approved by the chapter meeting.
 
 Other committee members are elected according to TMEIT's regulations.

--- a/pm/swe/pm_for_fortroendevalda_positioner.md
+++ b/pm/swe/pm_for_fortroendevalda_positioner.md
@@ -71,7 +71,8 @@ Listan får ändras utan att beslut behöver fattas på SM, var efter SM besluta
 - INGEN
 - NÅGON
 - MÅNGA
-- Ledamot - tre
+- Ledamot med ansvar för Budget
+- Ledamot - två
 
 #### 2.2.8 PIFF och PUFF
 

--- a/pm/swe/pm_for_fortroendevalda_positioner.md
+++ b/pm/swe/pm_for_fortroendevalda_positioner.md
@@ -83,16 +83,19 @@ Listan får ändras utan att beslut behöver fattas på SM, var efter SM besluta
 
 - TranditionsMästare
 - vice TraditionsMästare
+- Skattmästare
 
 #### 2.2.10 QMISK
 
 - QlubbMästare
 - vice QlubbMästare
+- Skattmästare
 
 #### 2.2.11 ITK
 
 - Root
 - Sudo
+- Byråkratisenator
 
 #### 2.2.12 Valberedningen
 

--- a/pm/swe/pm_for_iterativa_klubben.md
+++ b/pm/swe/pm_for_iterativa_klubben.md
@@ -21,7 +21,7 @@ För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet p�
 ITerativa Klubben leds av en ordförande benämnd root och en vice ordförande benämnd sudo, de ansvarar bägge för nämndens verksamhet.  
 Dessa godkännes av SM.
 
-ITerativa Klubben:s disponering av budget sköts av Byrokratisenator.  
+ITerativa Klubben:s disponering av budget sköts av Byråkratisenatorn.  
 Denne godkännes av SM.
 
 Övriga styrelsemedlemmar väljs enligt ITerativa Klubbens reglemente.

--- a/pm/swe/pm_for_iterativa_klubben.md
+++ b/pm/swe/pm_for_iterativa_klubben.md
@@ -21,7 +21,7 @@ För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet p�
 ITerativa Klubben leds av en ordförande benämnd root och en vice ordförande benämnd sudo, de ansvarar bägge för nämndens verksamhet.  
 Dessa godkännes av SM.
 
-ITerativa Klubben:s disponering av budget sköts av Byrokratisenator.
+ITerativa Klubben:s disponering av budget sköts av Byrokratisenator.  
 Denne godkännes av SM.
 
 Övriga styrelsemedlemmar väljs enligt ITerativa Klubbens reglemente.

--- a/pm/swe/pm_for_iterativa_klubben.md
+++ b/pm/swe/pm_for_iterativa_klubben.md
@@ -19,8 +19,10 @@ För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet p�
 ## 2 Organisation
 
 ITerativa Klubben leds av en ordförande benämnd root och en vice ordförande benämnd sudo, de ansvarar bägge för nämndens verksamhet.  
+Dessa godkännes av SM.
 
-De godkännes av SM.
+ITerativa Klubben:s disponering av budget sköts av Byrokratisenator.
+Denne godkännes av SM.
 
 Övriga styrelsemedlemmar väljs enligt ITerativa Klubbens reglemente.
 

--- a/pm/swe/pm_for_mottagningsnamnden.md
+++ b/pm/swe/pm_for_mottagningsnamnden.md
@@ -19,19 +19,13 @@ För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet p�
 
 Mottagningsnämnden består som minst av:
 
-- Ordförande och huvudansvarig, benämnd INitiationsGENeral (INGEN), som har det yttersta ansvaret och ordet avseende Mottagningen som helhet.  
-  Väljs av SM.
-- Vice ordförande.  
-  Ska i INGENs frånvaro utöva dennes befogenheter, och fullgöra dennes plikter.  
-  Är ekonomisk samordnare och fungerar som kontaktperson med sektionens kassör.  
-  Utöver detta innehar vice ordförande det ansvar som fördelas mellan denne och ordförande efter gemensam överenskommelse.  
-  Benämnd Neurotisk Åskådare till Generalens Ounvikliga Nederlag (NÅGON).
-  Väljs av SM.
-- Mastermottagningens ansvaige, som har yttersta ansvaret för- och ordet avseende mastermottagningen tillsammans med INGEN.
-  Benämnd Mastermottagningens Ångestfulla och Neurotiska Generellt Ansvarige (MÅNGA).
-  Väljs av SM.
-- Tre ledamöter i Mottagningsnämndens styrelse. Deras ansvarsområden bestäms av mottagningsnämnden i början av verksamhetsåret.  
-  De väljs av SM.
+- Ordförande och huvudansvarig (INGEN)
+- Vice ordförande (NÅGON)
+- Mastermottagningens ansvarige (MÅNGA)
+- Ledamot med ansvar för Budget
+- Två ledamöter i Mottagningsnämndens styrelse.
+
+Dessa väljs av SM.
 
 Mottagningens ledning, reglerat av Mottagningens reglemente, bygger själva upp strukturen inom nämnden.  
 Utöver detta står det Mottagningsnämnden fritt att internt definiera och tilldela ytterligare ansvarsposter för att hantera frågor såsom exempelvis evenemangsansvar och marknadsföring.
@@ -40,7 +34,26 @@ Mottagningsnämnden ska aktivt verka för att inkludera övriga nämnder i sina 
 
 Mottagningsansvarig åläggs att rapportera till ledamot med ansvar för studiesocial verksamhet i samband med sektionens styrelsemöten under hela verksamhetsåret.
 
-Val av Ordförande, Vice ordförande och Mastermottagningens ansvarige skall ske på första ordinarie Sektionsmöte efter Mottagningens avslutande.
+Val av Ordförande, vice Ordförande och Mastermottagningens ansvarige skall ske på första ordinarie Sektionsmöte efter Mottagningens avslutande.
+
+### 2.1 Ordförande och huvudansvarig (INGEN)
+Benämnd INitiationsGENeral (INGEN), som har det yttersta ansvaret och ordet avseende Mottagningen som helhet.
+
+### 2.2 vice Ordförande (NÅGON)
+Ska i INGENs frånvaro utöva dennes befogenheter, och fullgöra dennes plikter.
+Utöver detta innehar vice ordförande det ansvar som fördelas mellan denne och ordförande efter gemensam överenskommelse.
+Benämnd Neurotisk Åskådare till Generalens Ounvikliga Nederlag (NÅGON).
+
+### 2.3 Mastermottagningens ansvarige
+Har yttersta ansvaret för- och ordet avseende mastermottagningen tillsammans med INGEN.
+Benämnd Mastermottagningens Ångestfulla och Neurotiska Generellt Ansvarige (MÅNGA).  
+
+### 2.4 Ledamot med ansvar för Budget
+Är ekonomisk samordnare och fungerar som kontaktperson med sektionens kassör.
+Dennes uppgift är att disponera Mottagnigens budget.  
+
+### 2.5 Ledamöter
+Deras ansvarsområden bestäms av mottagningsnämnden i början av verksamhetsåret.
 
 ## 3 Ekonomi
 

--- a/pm/swe/pm_for_mottagningsnamnden.md
+++ b/pm/swe/pm_for_mottagningsnamnden.md
@@ -53,7 +53,7 @@ Benämnd Mastermottagningens Ångestfulla och Neurotiska Generellt Ansvarige (M�
 Dennes uppgift är att disponera Mottagnigens budget.  
 
 ### 2.5 Ledamöter
-Ansvarsområden bestäms av mottagningsnämnden i början av verksamhetsåret.
+Deras ansvarsområden bestäms av mottagningsnämnden i början av verksamhetsåret.
 
 ## 3 Ekonomi
 

--- a/pm/swe/pm_for_mottagningsnamnden.md
+++ b/pm/swe/pm_for_mottagningsnamnden.md
@@ -50,7 +50,7 @@ Benämnd Mastermottagningens Ångestfulla och Neurotiska Generellt Ansvarige (M�
 
 ### 2.4 Ledamot med ansvar för Budget
 Är ekonomisk samordnare och fungerar som kontaktperson med sektionens kassör.
-Dennes uppgift är att disponera Mottagnigens budget.  
+Dennes uppgift är att disponera Mottagningens budget.  
 
 ### 2.5 Ledamöter
 Deras ansvarsområden bestäms av mottagningsnämnden i början av verksamhetsåret.

--- a/pm/swe/pm_for_mottagningsnamnden.md
+++ b/pm/swe/pm_for_mottagningsnamnden.md
@@ -44,7 +44,7 @@ Ska i INGENs frånvaro utöva dennes befogenheter, och fullgöra dennes plikter.
 Utöver detta innehar vice ordförande det ansvar som fördelas mellan denne och ordförande efter gemensam överenskommelse.
 Benämnd Neurotisk Åskådare till Generalens Ounvikliga Nederlag (NÅGON).
 
-### 2.3 Mastermottagningens ansvarige
+### 2.3 Mastermottagningens ansvarige (MÅNGA)
 Har yttersta ansvaret för- och ordet avseende mastermottagningen tillsammans med INGEN.
 Benämnd Mastermottagningens Ångestfulla och Neurotiska Generellt Ansvarige (MÅNGA).  
 
@@ -53,7 +53,7 @@ Benämnd Mastermottagningens Ångestfulla och Neurotiska Generellt Ansvarige (M�
 Dennes uppgift är att disponera Mottagnigens budget.  
 
 ### 2.5 Ledamöter
-Deras ansvarsområden bestäms av mottagningsnämnden i början av verksamhetsåret.
+Ansvarsområden bestäms av mottagningsnämnden i början av verksamhetsåret.
 
 ## 3 Ekonomi
 

--- a/pm/swe/pm_for_qlubbmasteriet_in_sektionen_kista.md
+++ b/pm/swe/pm_for_qlubbmasteriet_in_sektionen_kista.md
@@ -23,7 +23,7 @@ För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet p�
 QMISK leds utav en Qlubbmästare och vice Qlubbmästare som ansvarar för driften.  
 Dessa godkännes av SM.
 
-QMISK:s disponering av budget sköts av Skattmästare.
+QMISK:s disponering av budget sköts av Skattmästare.  
 Denne godkännes av SM.
 
 Övriga medlemmar väljs enligt QMISK reglemente.

--- a/pm/swe/pm_for_qlubbmasteriet_in_sektionen_kista.md
+++ b/pm/swe/pm_for_qlubbmasteriet_in_sektionen_kista.md
@@ -23,6 +23,9 @@ För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet p�
 QMISK leds utav en Qlubbmästare och vice Qlubbmästare som ansvarar för driften.  
 Dessa godkännes av SM.
 
+QMISK:s disponering av budget sköts av Skattmästare.
+Denne godkännes av SM.
+
 Övriga medlemmar väljs enligt QMISK reglemente.
 
 ## 3 Ekonomi

--- a/pm/swe/pm_for_traditionsmesterit.md
+++ b/pm/swe/pm_for_traditionsmesterit.md
@@ -23,7 +23,7 @@ För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet p�
 TMEIT leds utav en Traditionsmästaren och vice Traditionsmästare som ansvarar för driften.  
 Dessa godkännes av SM.
 
-TMEIT:s disponering av budget sköts av Skattmästare.
+TMEIT:s disponering av budget sköts av Skattmästare.  
 Denne godkännes av SM.
 
 Övriga medlemmar väljs enligt TMEIT reglemente.

--- a/pm/swe/pm_for_traditionsmesterit.md
+++ b/pm/swe/pm_for_traditionsmesterit.md
@@ -20,10 +20,13 @@ För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet p�
 
 ## 2 Organisation
 
-TMEIT leds av Traditionsmästaren.  
-Bland TMEIT:s övriga medlemmar utses en vice Traditionsmästare, som hjälper Traditionsmästaren samt i dennes frånvaro fullgör dennes plikter.
+TMEIT leds utav en Traditionsmästaren och vice Traditionsmästare som ansvarar för driften.  
+Dessa godkännes av SM.
 
-Dessa två godkännes av SM.
+TMEIT:s disponering av budget sköts av Skattmästare.
+Denne godkännes av SM.
+
+Övriga medlemmar väljs enligt TMEIT reglemente.
 
 ## 3 Verksamhet
 


### PR DESCRIPTION
Update Memos for QMISK, TMEIT, ITK and the reception to have a person responsible for the committee's budget to be approved by SM. 

For the reception, this is moved away from NÅGON to this new board member (mux) role. Splitting up the previous 3 mux roles into 1 budget responsible and 2 normal muxes.

Editorial changes were made to Memo for Reception part §2 Organization to make it more readable.

[SM#5 2023 Protocol](https://drive.google.com/file/d/1DZXxVFiWpFHqLGuprCFmDi-qO1WYdOh1/view)
[Proposition](https://docs.google.com/document/d/1gKDulRXm4NpKQMrL1FvphgzSEq87oTMnEBhMLxLPsmI/view)