### PR TITLE
ValSM 24-11-11 Motion to Revamp International Coordinator

### DIFF
--- a/pm/eng/pm_for_fortroendevalda_positioner.md
+++ b/pm/eng/pm_for_fortroendevalda_positioner.md
@@ -9,7 +9,7 @@ The purpose of this Memo is to list all of the chapter's trustee elected positio
 ### 1.2 History
 
 Created: 2021-11-29  
-Last revision: 2023-12-05
+Last revision: 2024-11-11
 
 ### 1.3 Revising this Memo
 
@@ -71,7 +71,6 @@ The list may be changed without decisions at SM, where after SM decides on chang
 
 - INGEN
 - NÅGON
-- MÅNGA
 - Member responsible for Budget
 - Member - two
 
@@ -103,8 +102,11 @@ The list may be changed without decisions at SM, where after SM decides on chang
 
 - Convener
 - Member - at least 4
+  
+#### 2.2.13 JML
+- International Coordinator
 
-#### 2.2.13 Andra Positioner
+#### 2.2.14 Andra Positioner
 
 - Auditor - two
 - Safety officer

--- a/pm/eng/pm_for_jml.md
+++ b/pm/eng/pm_for_jml.md
@@ -6,11 +6,12 @@
 
 The purpose of this memo is to regulate the chapters JML committee.  
 The JML committee is responsible for long-term development of equality, diversity and equal conditions within the chapter.
+The JML committee is also responsible for furthering the integration and engagement of international students and to run Internationally-linked work for chapter members.
 
 ### 1.2 History
 
 Created: 2022-11-28  
-Last revision: 2023-12-05
+Last revision: 2024-11-11
 
 ### 1.3 Revising this Memo
 
@@ -22,14 +23,18 @@ In order to pass a revision of this Memo, a decision has to be made with a quali
 
 The JML board is composed of:
 - Board Member responsible for JML  
+- International Coordinator
 
 The JML committee includes:
 - JML-workgroup
+- International workgroup
 
 ### 2.2 Appointment
 All board representatives of the chapter's JML committee are elected by the Chapter Meeting.  
 
-The members of the JML-workgroup can be appointed by the JML committee's board.
+The members of the JML-workgroup can be appointed by the Board Member responsible for JML.
+
+The members of the International workgroup can be appointed by the International Coordinator.
 
 ## 3 Individual responsibility
 
@@ -51,6 +56,20 @@ These tasks include:
 ### 3.2 JML-Workgroup
 
 Tasked to work with JML questions in the chapter under the Board Member responsible for JML, leadership and with helping the Board Member responsible for JML to fulfill its responsibilities. 
+
+### 3.3 International Coordinator (Int)
+
+Is responsible for promoting the position of international students in the chapter as well as convening and chairing the International working group.
+
+The tasks of the International-coordinator includes:
+
+- To coordinate events with the chapter's various bodies that promote the integration and engagement of international students. 
+- To maintain a dialogue with THS International and attend their International Councils, or equivalent international related meetings concerning the chapter.
+- To coordinate with the International workgroup and the reception committee in order to plan, formulate and execute events during the reception period for all new masters and exchange students which will belong to the chapter during their studies at KTH.
+- To ensure that all information in the chapter is available in English.
+
+### 3.4 International workgroup
+Tasked to work with promoting the position, integration, and engagement of international students in the chapter under the International Coordinator. Members of the group that have actively contributed for a total of 25 working hours within a 4 month period, are eligible for a 0.2 GPA boost for exchange studies up to the discretion of the THS Head of International and the International Coordinator.
 
 ## 4 Logo
 

--- a/pm/eng/pm_for_mottagningsnamnden.md
+++ b/pm/eng/pm_for_mottagningsnamnden.md
@@ -9,7 +9,7 @@ The purpose of this memo is to regulate the Reception Committee
 ### 1.2 History
 
 Created: 2008-12-11  
-Last revision: 2023-12-05
+Last revision: 2024-11-11
 
 ### 1.3 Revising this Memo
 
@@ -21,7 +21,6 @@ The Reception committee is made up by at least:
 
 - President and main responsible (INGEN)
 - vice President (NÅGON)
-- Masters reception responsible (MÅNGA)
 - Board member responsible for Budget
 - Two board members
 
@@ -34,7 +33,7 @@ The Reception committee shall actively seek to include the chapter's other commi
 
 The chairperson is responsible to report to the board member responsible for studysocial activities before the chapter board's meetings during the whole business year.
 
-The chairperson, deputy chairperson and masters reception responsible are elected on the first ordinary chapter meeting following the end of the reception.
+The chairperson and deputy chairperson are elected on the first ordinary chapter meeting following the end of the reception.
 
 ### 2.1 President and main responsible (INGEN)
 Called INitiationsGENeral (INGEN), who has the main responsibility and final say regarding the Reception.
@@ -44,15 +43,11 @@ Shall in the absence of INGEN carry out INGEN's duties and execute INGEN's respo
 The vice chairperson is also responsible for the work delegated to them by INGEN by mutual agreement.
 Called Neurotisk Åskådare till Generalens Oundvikliga Nederlag (NÅGON).
 
-### 2.3 Masters reception responsible (MÅNGA)
-Has the main responsibility and the final say regarding the masters reception together with INGEN.
-Called Mastermottagningens Ångestfulla och Neurotiska Generellt Ansvarige (MÅNGA).
-
-### 2.4 Board Member responsible for Budget
+### 2.3 Board Member responsible for Budget
 Is responsible for the economy and contact for the chapter's treasurer.
 Shall manage the reception budget.
 
-### 2.5 Board Member
+### 2.4 Board Member
 Their areas of responsibilitiy is decided by the Reception committee.
 
 ## 3 Economy
@@ -71,9 +66,9 @@ For more extensive information please refer to the Rules for the Reception commi
 
 The operational year of the Reception committee starts when all members of the committee's board have been elected by the chapter meeting or the chapters operational year starts, whichever occurs first.
 
-### 4.1 Masters reception
+### 4.1 Masters and Exchange Reception
 
-The Reception committee shall formulate, plan and execute events for the new masters students at KTH in Kista.
+The Reception committee shall coordinate with the International Coordinator and any members of the International Workgroup to ensure that events are planned, formulated and executed for all new masters and exchange students beginning their studies, who will belong to the chapter during their studies at KTH.
 
 ## 5 Logo
 

--- a/pm/eng/pm_for_studiesociala_namnden.md
+++ b/pm/eng/pm_for_studiesociala_namnden.md
@@ -5,13 +5,12 @@
 ### 1.1 Purpose
 
 This Memo regulates the chapter's Study Social Committee.  
-The Study Social Committee is responsible for developing student life within the chapter in the long term.  
-To collaborate with the operational bodies within the chapter that carry out that work and run INternationally-linked work for chapter members.
+The Study Social Committee is responsible for developing student life within the chapter in the long term.
 
 ### 1.2 History
 
 Established: 2020-05-20  
-Last revision: 2022-11-28
+Last revision: 2024-11-11
 
 ### 1.3 Revisions to this Memo
 
@@ -24,19 +23,13 @@ In order to pass a revision of this Memo a decision has to be made with a qualif
 The Study Social board is composed of:
 
 - President and Board Member responsible for study social activities.  
-- INternational-coordinator (INt)
 
 The Study Social board can elect more board members.  
 An individual chapter member may only occupy one seat on the board at any given time.  
 
-The Study Social Committee can also include:  
-
-- INternational-workgroup
-
 ### 2.2 Appointment
 
-All board representatives of the chapter's Study Social Committee are elected by the Chapter Meeting.  
-- Members of the INternational-workgroup are appointed by the board of the Study Social Committee.
+All board representatives of the chapter's Study Social Committee are elected by the Chapter Meeting.
 
 ## 3 Individual responsibility
 
@@ -61,14 +54,3 @@ The tasks of the JML-coordinator includes:
 - To organize and hold a JML-workshop for new students during the reception. 
 - To organize and hold a JML-workshop for those who participate in the reception of new students during the reception. 
 - To arrange and hold a JML-workshop so that the chapter's board and those who hold a position of trust within the chapter have the opportunity to participate at least once during their term of office.
-
-### 3.3 INternational-coordinator (INt)
-
-Is responsible for promoting the position of international students in the section as well as convening and chairing the INternational working group.
-
-The tasks of the INternational-coordinator includes:
-
-- To coordinate events with the chapter's various bodies that promote the integration of international students. 
-- To maintain a dialogue with THS International and attend their International Councils, or equivalent international related meetings concerning the chapter.
-- To work to ensure that international students are received during the reception periods.
-- To work to ensure that all information is available in English.

--- a/pm/swe/pm_for_fortroendevalda_positioner.md
+++ b/pm/swe/pm_for_fortroendevalda_positioner.md
@@ -9,7 +9,7 @@ Denna PM är avsedd till att lista alla sektionens förtroendevalda positioner.
 ### 1.2 Historik
 
 Upprättat: 2021-11-29  
-Senast ändrat: 2023-12-05
+Senast ändrat: 2024-11-11
 
 ### 1.3 Ändrande av PM
 
@@ -71,7 +71,6 @@ Listan får ändras utan att beslut behöver fattas på SM, var efter SM besluta
 
 - INGEN
 - NÅGON
-- MÅNGA
 - Ledamot med ansvar för Budget
 - Ledamot - två
 
@@ -104,7 +103,10 @@ Listan får ändras utan att beslut behöver fattas på SM, var efter SM besluta
 - Sammankallande
 - Medlem - minst 4
 
-#### 2.2.13 Andra Positioner
+#### 2.2.13 JML
+- Internationell-koordinator
+
+#### 2.2.14 Andra Positioner
 
 - Revisor - två
 - Skyddsvårdsombud

--- a/pm/swe/pm_for_jml.md
+++ b/pm/swe/pm_for_jml.md
@@ -6,11 +6,12 @@
 
 Detta PM reglerar sektionens JML nämnd.
 JML nämnden ansvarar för att långsiktigt utveckla jämställdhet, mångfald och lika villkor inom sektionen.
+JML nämnden ansvarar även för att främja integration och engagemang av internationella studenter samt att driva internationellt-kopplat arbete för sektionsmedlemmar.
 
 ### 1.2 Historik
 
 Upprättat: 2022-11-28  
-Senast ändrat: 2023-12-05
+Senast ändrat: 2024-11-11
 
 ### 1.3 Ändrande av PM
 
@@ -22,15 +23,18 @@ För ändrande av denna PM krävs ett beslut taget med kvalificerad majoritet p�
 
 JML nämndens styrelse består av:
 - Styrelseledamot med ansvar för JML-verksamhet
+- Internationell-koordinator
 
 JML nämnden innehåller:
 - JML-arbetsgrupp
+- Internationell-arbetsgrupp
 
 ### 2.2 Tillsättning
 
 Samtliga av JML Nämndens styrelserepresentanter väljs av SM.
 
 JML-arbetsgruppen tillsätts av JML Nämndens styrelse.
+Internationell-arbetsgruppen tillsätts av JML Nämndens styrelse.
 
 ## 3 Verksamhet
 
@@ -53,6 +57,17 @@ I dessa uppgifter ingår:
 ### 3.2 JML-Arbetsgrupp
 
 Arbetar med JML-frågor inom sektionen under Styrelseledamot med ansvar för JML-verksamhets ledning och hjälper Styrelseledamot med ansvar för JML-verksamhet att uppfylla sina uppgifter.  
+
+### 3.3 Internationell-kooordinator
+Ansvarar för att främja internationella studenters plats i sektionen samt sammankallande- och styrande för Internationell-arbetsgruppen.
+I dessa uppgifter ingår:
+- Att koordinera event med sektionens olika organ som främjar integrationen av internationella studenter.
+- Att hålla en dialog med THS International och närvara på deras International Councils, eller motsvarande möten.
+- Att samordna med den Internationella-arbetsgruppen och Mottagningsnämnden för att säkerställa att evenemang utarbetas, planeras och genomföras för alla nya masterstudenter och utbytesstudenter som påbörjar sina studier och som kommer att tillhöra sektionen under sina studier vid KTH.
+- Att arbeta för att all information finns tillgänglig på engelska.
+
+### 3.4 Internationell=Arbetsgrupp
+Arbetar med att främja internationella studenters ställning, integration och engagemang i sektionen under Internationell-koordinators ledning. De arbetar också tillsammans med den Internationella-koordinatorn och Mottagningsnämnden för att säkerställa att evenemang planeras och genomförs för alla nya masterstudenter och utbytesstudenter som påbörjar sina studier och som kommer att tillhöra sektionen under sina studier vid KTH. Medlemmar i den Internationella arbetsgruppen som aktivt har bidragit med totalt 25 arbetstimmar under en 4-månadersperiod är berättigade till en GPA-boost på 0,2 för utbytesstudier enligt beslut av THS Head of International och den Internationella-koordinatorn.
 
 ## 4 Logotyp
 

--- a/pm/swe/pm_for_mottagningsnamnden.md
+++ b/pm/swe/pm_for_mottagningsnamnden.md
@@ -9,7 +9,7 @@ Denna PM är avsedd att reglera Mottagningsnämnden.
 ### 1.2 Historik
 
 Upprättat: 2008-12-11  
-Senast ändrat: 2023-12-05
+Senast ändrat: 2024-11-11
 
 ### 1.3 Ändrande av PM
 
@@ -21,7 +21,6 @@ Mottagningsnämnden består som minst av:
 
 - Ordförande och huvudansvarig (INGEN)
 - Vice ordförande (NÅGON)
-- Mastermottagningens ansvarige (MÅNGA)
 - Ledamot med ansvar för Budget
 - Två ledamöter i Mottagningsnämndens styrelse.
 
@@ -34,7 +33,7 @@ Mottagningsnämnden ska aktivt verka för att inkludera övriga nämnder i sina 
 
 Mottagningsansvarig åläggs att rapportera till ledamot med ansvar för studiesocial verksamhet i samband med sektionens styrelsemöten under hela verksamhetsåret.
 
-Val av Ordförande, vice Ordförande och Mastermottagningens ansvarige skall ske på första ordinarie Sektionsmöte efter Mottagningens avslutande.
+Val av Ordförande och vice Ordförande skall ske på första ordinarie Sektionsmöte efter Mottagningens avslutande.
 
 ### 2.1 Ordförande och huvudansvarig (INGEN)
 Benämnd INitiationsGENeral (INGEN), som har det yttersta ansvaret och ordet avseende Mottagningen som helhet.
@@ -44,15 +43,11 @@ Ska i INGENs frånvaro utöva dennes befogenheter, och fullgöra dennes plikter.
 Utöver detta innehar vice ordförande det ansvar som fördelas mellan denne och ordförande efter gemensam överenskommelse.
 Benämnd Neurotisk Åskådare till Generalens Ounvikliga Nederlag (NÅGON).
 
-### 2.3 Mastermottagningens ansvarige (MÅNGA)
-Har yttersta ansvaret för- och ordet avseende mastermottagningen tillsammans med INGEN.
-Benämnd Mastermottagningens Ångestfulla och Neurotiska Generellt Ansvarige (MÅNGA).  
-
-### 2.4 Ledamot med ansvar för Budget
+### 2.3 Ledamot med ansvar för Budget
 Är ekonomisk samordnare och fungerar som kontaktperson med sektionens kassör.
 Dennes uppgift är att disponera Mottagningens budget.  
 
-### 2.5 Ledamöter
+### 2.4 Ledamöter
 Deras ansvarsområden bestäms av mottagningsnämnden i början av verksamhetsåret.
 
 ## 3 Ekonomi
@@ -71,9 +66,9 @@ För utförligare information se Reglemente för Mottagningsnämnden.
 
 Verksamhetsåret för Mottagningsnämnden börjar då hela mottagningsstyrelsen för nästkommande år valts av SM eller sektionens verksamhetsår börjar, vilket som än sker först.
 
-### 4.1 Mastermottagningen
+### 4.1 Master- & Utbytes-mottagning
 
-Mottagningsnämnden skall utarbeta, planera och genomföra evenemang för nyantagna masterstudenter vid KTH i Kista.
+Mottagningsnämnden skall samordna med den Internationell-koordinatorn och eventuella medlemmar i Internationella-arbetsgruppen för att säkerställa att evenemang utarbetas, planeras och genomföras för alla nya masterstudenter och utbytesstudenter som påbörjar sina studier och som kommer att tillhöra sektionen under sina studier vid KTH.
 
 ## 5 Logotyp
 

--- a/pm/swe/pm_for_studiesociala_namnden.md
+++ b/pm/swe/pm_for_studiesociala_namnden.md
@@ -5,13 +5,12 @@
 ### 1.1 Syfte
 
 Detta PM reglerar sektionens studiesociala nämnd.  
-Studiesociala nämnden ansvarar för att långsiktigt utveckla studentlivet inom sektionen.  
-Att samarbeta med de operativa organ inom sektionen som utför arbetet och driva INternationellt-kopplat arbete för sektionsmedlemmar.  
+Studiesociala nämnden ansvarar för att långsiktigt utveckla studentlivet inom sektionen.
 
 ### 1.2 Historik
 
 Upprättat: 2020-05-20  
-Senast ändrat: 2022-11-28  
+Senast ändrat: 2024-11-11
 
 ### 1.3 Ändrande av PM
 
@@ -23,20 +22,14 @@ För ändrande av detta PM krävs ett beslut med kvalificerad majoritet på ett 
 
 Studiesociala nämndens styrelse består av:  
 
-- Ordförande samt styrelseledamot med ansvar för Studiesocial verksamhet.  
-- Internationell-koordinator (INt)  
+- Ordförande samt styrelseledamot med ansvar för Studiesocial verksamhet.    
 
 Studiesociala nämnden kan välja in fler styrelseledamöter.
 Enskild sektionsmedlem får endast inneha en styrelsepost åt gången.  
 
-Studiesociala nämnden kan även innehålla:  
-
-- INternationell-arbetsgrupp
-
 ### 2.2 Tillsättning
 
 Samtliga av Studiesociala Nämndens styrelserepresentanter väljs av SM.  
-- Medlemmar i INternationella-arbetsgruppen tillsätts av Studiesociala Nämndens styrelse.
 
 ## 3 Verksamhet
 
@@ -61,14 +54,3 @@ I dessa uppgifter ingår:
 - Att anordna och hålla i en JML-workshop för nya studenter under mottagningen.  
 - Att anordna och hålla en JML-workshop för de som deltar i mottagandet av nya studenter under mottagningen.  
 - Att anordna och hålla i en JML-workshop så att sektionens styrelse och de som innehar en förtroendevald position inom sektionen har möjlighet att delta minst en gång under deras mandatperiod.  
-
-### 3.3 INternationell-koordinator
-
-Ansvarar för att främja internationella studenters plats i sektionen samt sammankallande- och styrande för INternationella-arbetsgruppen. 
-
-I dessa uppgifter ingår:
-
-- Att koordinera event med sektionens olika organ som främjar integrationen av internationella studenter. 
-- Att hålla en dialog med THS International och närvara på deras International Councils, eller motsvarande möten.
-- Att arbeta för att internationella studenter blir mottagna under mottagningsperioderna.
-- Att arbeta för att all information finns tillgänglig på engelska.


### PR DESCRIPTION
Includes all changes proposed by the Motion to Revamp International Coordinator, to be voted on at ValSM 2024

https://docs.google.com/document/d/181g4Fus8nO-KsIGbz5SSjA1_JOoGb_P6CJrKHsuyq40/edit?tab=t.0