### PR TITLE
Update §1.10.1 Chapter Birthday

### DIFF
--- a/stadgar/eng/stadgar.md
+++ b/stadgar/eng/stadgar.md
@@ -136,7 +136,7 @@ The chapter board may suggest other signatories that the chapter meeting can app
 
 ### §1.10 The chapter's birthday
 
-§1.10.1 The chapter's birthday is December the fourth 2008.
+§1.10.1 The chapter's birthday is September 12, 2000.
 
 ## §2 Regulatory documents
 

--- a/stadgar/swe/stadgar.md
+++ b/stadgar/swe/stadgar.md
@@ -133,7 +133,7 @@ Sektionsstyrelsen kan även föreslå andra firmatecknare som sektionsmötet kan
 
 ### §1.10 Sektionens födelsedag
 
-§1.10.1 Sektionens födelsedag infaller den 4 december 2008.
+§1.10.1 Sektionens födelsedag infaller den 12 september 2000.
 
 ## §2 Styrdokument
 


### PR DESCRIPTION
THS still classifies the chapter’s birthdate as 12 September 2000, the day the IT-chapter was created. In our statutes, it says 4 December 2008, which is the date of the merger of the IT and ME chapters. Now as we are going back to the IT chapter, it is appropriate to update the bylaws so that the birthday of the chapter is the same as that of THS, September 12, 2000.

[Proposition](https://docs.google.com/document/d/1ay4purcdbTjeX4aCEwnRSRjtuAj3qDlUdnHAufLtL2c/edit?usp=sharing)