### PR TITLE
Remove left over JML coordinator in Study Social Committee Memo

### DIFF
--- a/pm/eng/pm_for_studiesociala_namnden.md
+++ b/pm/eng/pm_for_studiesociala_namnden.md
@@ -40,17 +40,3 @@ Convener and president of the Study social committee is the board member respons
 The board member is responsible for ensuring that meetings with the entire committee are held prior to each board meeting.
 
 Their responsibilities and duties are further regulated in the "Memo for the Chapters Board".
-
-### JML-coordinator
-
-Is responsible for running the chapter's JML work and to be the convening responsible and leader of the JML team.
-
-The tasks of the JML-coordinator includes:
-
-- To spread the knowledge and understanding of JML to the chapter members.
-- To inform about the chapter’s JML work to all chapter members.
-- To help chapter members with JML issues according to the chapter's action plan called "Planned course of action in JML matters".
-- To take part in the Train-the-Trainer education given by the KTH equality office with one or more members from the Study Social Committee.
-- To organize and hold a JML-workshop for new students during the reception.
-- To organize and hold a JML-workshop for those who participate in the reception of new students during the reception.
-- To arrange and hold a JML-workshop so that the chapter's board and those who hold a position of trust within the chapter have the opportunity to participate at least once during their term of office.

--- a/pm/swe/pm_for_studiesociala_namnden.md
+++ b/pm/swe/pm_for_studiesociala_namnden.md
@@ -40,17 +40,3 @@ Sammankallande och ordförande för studiesociala nämnden är styrelseledamot m
 Styrelseledamoten ansvarar för att möten med hela nämnden hålls inför varje styrelsemöte.  
 
 Dennes ansvar och plikter regleras i "PM för Sektionens Styrelse".  
-
-### 3.2 JML-koordinator
-
-Ansvar för att driva sektionens JML-arbete och att vara sammankallande samt styrande för JML-arbetsgruppen.  
-
-I dessa uppgifter ingår:
-
-- Att sprida kunskap och förståelse om JML till sektionens medlemmar.  
-- Att informera om sektionens JML-arbete till sektionens medlemmar.  
-- Att hjälpa sektionsmedlemmar med JML-frågor enligt sektionens handlingsplan benämnd "Handlingsplan inom JML-kopplade ärenden".  
-- Att delta i Train-the-Trainer utbildningen som anordnas av KTH Equality office med en eller flera medlemmar från studiesociala nämnden.  
-- Att anordna och hålla i en JML-workshop för nya studenter under mottagningen.  
-- Att anordna och hålla en JML-workshop för de som deltar i mottagandet av nya studenter under mottagningen.  
-- Att anordna och hålla i en JML-workshop så att sektionens styrelse och de som innehar en förtroendevald position inom sektionen har möjlighet att delta minst en gång under deras mandatperiod.


### PR DESCRIPTION
Fully remove the JML coordinator from the Study Social Committee. It was missed when the JML committee was created with #19.

Old motions and protocols from 2022:
[Motion for JML Board post](https://docs.google.com/document/d/1vkfdRaqfVRplTpvDsBFu3XCSLnjirnxKsTS1JQmomuI/edit)
[Motion answer for "Motion for JML Board Post"](https://docs.google.com/document/d/1px8uwwvR3WRkyZSDN2inH1Z0Afsd9oZSaO5gQGWHHkg/view)
[First vote at SM#3 2022 (Protocol)](https://drive.google.com/file/d/1za-oFJUo3p4fkMUSdlIrFmRuf930DCya/view)
[Second vote at SM#4 2022 (Protocol)](https://drive.google.com/file/d/1CgwhopIIuvCETZJhyCGSaVhFEbmcTlBS/view)  