### PR TITLE
Remove left over International Students from Communications Committee Memo

### DIFF
--- a/pm/eng/pm_for_kommunikationsnamnden.md
+++ b/pm/eng/pm_for_kommunikationsnamnden.md
@@ -81,16 +81,6 @@ The responsibilities include:
 - to inform the alumni members about those events in the chapter that may be of interest in them  
 - to arrange events where the chapter's members can meet and network with alumni members, such as alumni pubs
 
-### 3.4 International students
-
-The committee for communications has a general responsibility for the communication with the international students of the school of EECS at campus KTH Kista.  
-
-These responsibilities include:
-
-- to help the new students when they start, for example by arranging tours of the campus and providing them with important and helpful information  
-- to invite the international students to the chapter's different events, such as pubs, LAN parties, gasques and chapter meetings  
-- to ensure that information from the chapter is available in english
-
 ## 4 Economy
 
 The committee has no economy of its own.

--- a/pm/swe/pm_for_kommunikationsnamnden.md
+++ b/pm/swe/pm_for_kommunikationsnamnden.md
@@ -82,16 +82,6 @@ I dessa uppgifter ingår:
 - att informera alumnimedlemmarna om de av sektionens event som kan vara intressanta för dessa  
 - att anordna event där sektionens medlemmar kan träffa och knyta kontakter med alumnimedlemmar, som t.ex. alumnipub
 
-### 3.4 Internationella studenter
-
-Kommunikationsnämnden har ett övergripande ansvar för kommunikationen med de internationella studenterna på EECS-skolan på campus KTH Kista.
-
-I dessa uppgifter ingår:
-
-- att hjälpa de nya studenterna vid start, genom att exempelvis anordna rundvandring och ge ut nyttig information  
-- att bjuda in de internationella studenterna till sektionens olika event, som pubar, LAN, sittningar och sektionsmöten  
-- att arbeta för att information från sektionen finns tillgänglig på engelska
-
 ## 4 Ekonomi
 
 Nämnden har ej egen ekonomi.


### PR DESCRIPTION
Fully remove §3.4 International Students from the Communications Committee Memo as it was missed in the lumped changes in the propositions, merged with #13. 

Protocol and Proposition from 2021:
[SM#5 2021 Protocol](https://drive.google.com/file/d/1J5K7oolH8baoOZGPyhVsy_pODmXMS6H7/view)
[Proposition for change of “PM for Study Social”](https://docs.google.com/document/d/1erxdNHVdhskUPswOManZnBW_WGT2bnDoIM8-PWAH2YQ/edit)