### PR TITLE
Add linter and PR reminder comments

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,27 +1,72 @@
-name: PR Reminder comment
+name: PR Reminder
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, edited]
 
 jobs:
-  remind-common-issues:
+  comment:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
       - name: Post comment
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9.0.0
         with:
           script: |
-            github.rest.issues.createComment({
+            const prTitle = context.payload.pull_request.title;
+            const action = context.payload.action;
+            const titleChanged = context.payload.changes?.title;
+
+            // Unique identifier for the bot's comment
+            const COMMENT_IDENTIFIER = '<!-- pr-reminder-bot -->';
+
+            if (action === "edited" && !titleChanged) {
+              return;
+            }
+
+            const suffixPattern = /\s-\s(SM#\d+\s\d{4}(?:\/SM#\d+\s\d{4})*)\s-\s(\d{4}-\d{2}-\d{2}(?:\/\d{4}-\d{2}-\d{2})*)$/;
+            const match = prTitle.match(suffixPattern);
+
+            let body = `### PR Reminders
+            Please ensure the following:
+            - Link the signed protocol and relevant files.
+            - Update the revision dates.
+            - Only have one sentence per line.
+            - Do not break single sentences onto multiple lines.`;
+
+            if (!match) {
+              body += `\n\n### ⚠️ Invalid PR Title Suffix
+            Expected title suffix:
+            - Single: \` - SM#X 20YY - 20YY-MM-DD\`
+            - Multiple: \` - SM#X 20YY/SM#X 20YY - 20YY-MM-DD/20YY-MM-DD\`
+
+            _This is not needed for editorial or non memo/statutes changes._`;
+            }
+
+            body += `\n\n${COMMENT_IDENTIFIER}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `### PR Reminders
-              Please ensure the following:
-              - Link the signed protocol and relevant files.
-              - Update the revision dates.
-              - Only have one sentence per line.
-              - Do not break single sentences onto multiple lines.`
-            })
+            });
+            const existingComment = comments.find(comment =>
+              comment.user.login === 'github-actions[bot]' && comment.body.includes(COMMENT_IDENTIFIER)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                comment_id: existingComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body,
+              });
+            }

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -44,6 +44,10 @@ jobs:
             _This is not needed for editorial or non memo/statutes changes._`;
             }
 
+            body += `\n\n### Merging Instructions
+            _Maintainers will merge this pull request using squash and merge with the following commit message format prefix, if the changes have been voted on at a chapter meeting: `SMX 20YY-<changes>`_
+            _All merges will be merged in chronological order of the dates they got approved by a chapter meeting._`;
+
             body += `\n\n${COMMENT_IDENTIFIER}`;
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,0 +1,27 @@
+name: PR Reminder comment
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  remind-common-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### PR Reminders
+              Please ensure the following:
+              - Link the signed protocol and relevant files.
+              - Update the revision dates.
+              - Only have one sentence per line.
+              - Do not break single sentences onto multiple lines.`
+            })

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint Markdown files
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.x"
+
+      - name: Run validation script
+        run: python scripts/validate_markdown.py

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "yzhang.markdown-all-in-one",
+    "davidanson.vscode-markdownlint"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -36,11 +36,7 @@ Before writing a motion or proposition that changes some regulatory document, re
     └── swe
 ```
 
-## Tips and tricks
-
-- If you are using VS Code, the plugin [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) greatly helps the editing process.
-
-### And lastly
+## And lastly
 
 §2.1.3 of the chapter's statutes clearly state that _all_ of the chapter's regulatory documents must be published on _the chapter's website_.
 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,27 @@
-# styrdokument
+# IT-sektionens styrdokument
 
 Regulatory documents belonging to the Chapter for Information Technology, written in Markdown.  
 The compiled documents are available in PDF form under [the repository's "**Releases**" page](https://github.com/insektionen/styrdokument/releases)
 
-See [Markdown Cheat sheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) for an introduction to Markdown syntax.
-
-A more in-depth introduction to writing Markdown is provided [here by GitHub](https://docs.github.com/en/get-started/writing-on-github).
-
-You should conform to GitHub Flavored Markdown (GFM) when editing these documents, [the formal specification for that dialect can be found here](https://github.github.com/gfm/).
+- See [Markdown Cheat sheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) for an introduction to Markdown syntax.
+- A more in-depth introduction to writing Markdown is provided [here by GitHub](https://docs.github.com/en/get-started/writing-on-github).
+- You should conform to GitHub Flavored Markdown (GFM) when editing these documents, [the formal specification for that dialect can be found here](https://github.github.com/gfm/).
 
 ## Repository rules
 
 1. **ONE SENTENCE PER LINE** - in order to make it easier to refer to specific changes, sentences, or sections of text in the files.
-2. **ONLY PULL REQUESTS MAY CHANGE THE MAIN BRANCH** - in order to make sure that we are *all* accountable, and that it is easy to audit historic changes.
+2. **ONLY PULL REQUESTS MAY CHANGE THE MAIN BRANCH** - in order to make sure that we are _all_ accountable, and that it is easy to audit historic changes.
 3. **ALL PULL REQUESTS MUST BE ACCOMPANIED BY A MOTION OR PROPOSITION** - as the chapter meeting must approve all changes to the regulatory documents.
-4. **PROPOSED CHANGES ARE MADE BY CLONING THE REPO AND THEN CREATING A PULL REQUEST** - in addition to #2, direct changes to this repo should be avoided as far as possible.
+4. **PROPOSED CHANGES ARE MADE BY BRANCHING OR FORKING THE REPO AND THEN CREATING A PULL REQUEST** - in addition to #2, direct changes to this repo should be avoided as far as possible.
 5. **PDF VERSIONS OF THE DOCUMENTS ARE PROVIDED AS RELEASES, NOT WITHIN THE REPO** - new changes or additions -> new release, this is automated via GitHub Actions.
 
-## Writing motions or propositions and using this repository
-
-When writing a motion or proposition that changes some regulatory document, do the following:
-
-1. Fork this repository
-2. Perform the changes that are part of the motion *in your own fork*, **not** in this repository or any of its branches.
-3. Create a pull request in this repository, link to and briefly describe your motion in the pull request.
-4. Link to the pull request in your motion; and in the motion explicitly state which line(s) in the affected file(s) that you want to change.
-5. Any additions or changes to the proposed changes are done as suggested changes in the pull request on GitHub.
+Before writing a motion or proposition that changes some regulatory document, read through and follow the full [Contribution guidelines](docs/CONTRIBUTING.md).
 
 ## Repository structure
 
 ```text
+├── .github - workflows for automatic builds and tests
+├── docs - documentation on how to contribute and templates
 ├── archive - old regulatory documents
 ├── img - images required by the regulatory documents
 ├── other_documents - regulations for clubs, the chapter's vision plan
@@ -38,6 +30,7 @@ When writing a motion or proposition that changes some regulatory document, do t
 ├── pm - the chapter's memos
 │   ├── eng
 │   └── swe
+├── stricts - scrips needed for builds and tests
 └── stadgar - the chapter's statutes
     ├── eng
     └── swe
@@ -47,17 +40,16 @@ When writing a motion or proposition that changes some regulatory document, do t
 
 - If you are using VS Code, the plugin [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) greatly helps the editing process.
 
-## A comment on performing minor changes such as correcting spelling
-
-All chapter secretaries are **strongly** urged to learn how to utilize editorial changes, this process is known as "redaktionella ändringar" in swedish.  
-This greatly cuts down on the deluge of unnecessary propositions from the chapter's board that usually follows any read-through of, or plan to make miniscule changes to, the chapter's regulatory documents.  
-This does, however, **not** exempt you from the repository's ruleset.
-
 ### And lastly
 
-§2.1.3 of the chapter's statutes clearly state that *all* of the chapter's regulatory documents must be published on *the chapter's website*.  
-The release page, that each repository on GitHub has, is *not* the chapter's website.  
-Do not use the release page of this repository as the sole storage of the regulatory documents.  
-So, **if you lose these documents again I will find you!** [imagine a photo of Liam Neeson holding a cellphone]  
-If you actually need *any* help with this repo, contact me, really.  
-Signed, Ordf 2016
+§2.1.3 of the chapter's statutes clearly state that _all_ of the chapter's regulatory documents must be published on _the chapter's website_.
+
+The release page, that each repository on GitHub has, is _not_ the chapter's website.
+Do not use the release page of this repository as the sole storage of the regulatory documents.
+
+In addition, to ensure the longevity and clean history, please review each other's work thoroughly and merge things in cronological order.
+Countless hours have gone into getting all this caught up and organized, so please check an extra time to make sure you don't mess it up.
+
+So, **if you lose or mess up these documents again we will find you!** [imagine a photo of Liam Neeson holding a cellphone]  
+If you actually need _any_ help with this repo, contact any of us, really.  
+Signed, Ordförande 2016 & Sekreterare 2022

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,7 +8,7 @@ This is compared to a fork, which relies on that single person to fix.
 
 1. Branch/Fork this repository
 2. Perform the changes that are part of the motion _in your own branch/fork_, **not** in the main branch of this repository.
-   (It should be locked for all non-PR merges).
+   (It should be locked for all non-pull request merges).
 3. Create a pull request in this repository, link to and briefly describe your motion in the pull request.
 4. Link to the pull request in your motion.
 5. Any additions or changes to the proposed changes should be done as suggested changes in the pull request on GitHub.
@@ -32,19 +32,25 @@ For example:
 - `Add vice JML president role - SM#1 2025 - 2025-01-20`
 - `Update §5.3.3 discharge to 6 months - SM#5 2023/SM#1 2024 - 2023-12-05/2024-01-23` if it has been voted on twice.
 
+### Description
+
+In the pull request rescription, add a short explaination of what is changed.
+Together with a link to the propositin/motion as well as the signed chapter meeting protocol.
+
 ### Labeling
 
-Always assign the related labels to the PR.
+Always assign the related labels to the pull request.
 This includes if the statutes, memos or if it includes editorial changes.
-This is to more easily see which PR has changed what types of files.
+This is to more easily see which pull request has changed what types of files.
 
-To be able to label the PR, you might need specific access to the repository.
+To be able to label the pull request, you might need specific access to the repository.
 Therefore, those who have it need to add these labels if they are missing.
 
 ### Reviewing
 
-It's highly recommended that someone reviews your PR before it gets merged.
+It's highly recommended that someone reviews your pull request before it gets merged.
 Small errors might not be found for years and can be hard to track down whether they were intended or not.
+Double check the points in the PR reminder comment if all things are correct.
 
 Every time something has been voted to be changed with a proposition or a motion at a chapter meeting, the revision date of the affected documents needs to be changed.
 This is often missed, so always double-check this before merging.
@@ -54,9 +60,9 @@ This is often missed, so always double-check this before merging.
 All pull requests **must** be merged _in chronological order_ of the dates they got approved by a chapter meeting.
 If multiple pull requests were voted on at the same chapter meeting, the internal order is not important.
 
-In order for a PR to be merged, it needs to be approved by the chapter meeting.
+In order for a pull request to be merged, it needs to be approved by the chapter meeting.
 
-There are formatting rules to follow for this repository that will be checked on every PR automatically.
+There are formatting rules to follow for this repository that will be checked on every pull request automatically.
 These are in place to find blatant errors.
 However, some things might slip through and they are not super strict, so you always need to double-check your work.
 
@@ -77,7 +83,7 @@ However, some things might slip through and they are not super strict, so you al
 
 As mentioned in the [README](../README.md) repository rules, all changes will be automatically built to the repository's releases.
 As a secretary, you should manage these releases.
-If multiple PRs have been merged, only keep the last one for each SM.
+If multiple pull requests have been merged, only keep the last one for each SM.
 Label the release with the SM and year the changes originate from.
 Update the text, explaining what has changed.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -32,6 +32,12 @@ For example:
 - `Add vice JML president role - SM#1 2025 - 2025-01-20`
 - `Update §5.3.3 discharge to 6 months - SM#5 2023/SM#1 2024 - 2023-12-05/2024-01-23` if it has been voted on twice.
 
+### Scope
+
+Each pull request must address only **one proposition/motion**.
+If multiple changes were voted on, create separate pull requests for each.
+This keeps the merge history clear and makes it easier to track and revert individual changes if needed.
+
 ### Description
 
 In the pull request rescription, add a short explaination of what is changed.
@@ -78,6 +84,10 @@ However, some things might slip through and they are not super strict, so you al
    - Same dates in both files.
    - Same number of lines.
    - Same header numbering.
+
+Always merge using _squash and merge_, to keep the commit history clean and linear.
+Prefix the commit message with `SMX 20YY-` if it's a change voted on at a chapter meeting.
+This makes the history easier to navigate and to catch if things have been merged out of order.
 
 ## Releases
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -106,3 +106,7 @@ Update the text, explaining what has changed.
 As a secretary, you can also create a custom named tag for the release.
 This allows everyone to easily find a previous state of the repository.
 These tags should be named `20XX-SMX`, like `2025-SM3`.
+
+## Tips and tricks
+
+- If you are using VS Code, the plugins [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) and [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one) greatly helps the editing process.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Double check the points in the PR reminder comment if all things are correct.
 Every time something has been voted to be changed with a proposition or a motion at a chapter meeting, the revision date of the affected documents needs to be changed.
 This is often missed, so always double-check this before merging.
 
-### Mergning
+### Merging
 
 All pull requests **must** be merged _in chronological order_ of the dates they got approved by a chapter meeting.
 If multiple pull requests were voted on at the same chapter meeting, the internal order is not important.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# How to contribute
+
+## Writing motions or propositions and using this repository
+
+Depending on whether you have access to the repository or not, you may create a fork or a branch.
+For the chapter secretaries and board, it's highly recommended to make changes in branches, as changes voted at the chapter meeting can be fixed by anyone with access.
+This is compared to a fork, which relies on that single person to fix.
+
+1. Branch/Fork this repository
+2. Perform the changes that are part of the motion _in your own branch/fork_, **not** in the main branch of this repository.
+   (It should be locked for all non-PR merges).
+3. Create a pull request in this repository, link to and briefly describe your motion in the pull request.
+4. Link to the pull request in your motion.
+5. Any additions or changes to the proposed changes should be done as suggested changes in the pull request on GitHub.
+
+### Performing minor changes such as correcting spelling
+
+All chapter secretaries are **strongly** urged to learn how to utilize editorial changes.
+This process is known as "redaktionella ändringar" in Swedish.
+This greatly cuts down on the deluge of unnecessary propositions from the chapter's board that usually follows any read-through of, or plan to make minuscule changes to, the chapter's regulatory documents.
+Especially if the English parts of the statutes do not match the Swedish, then they can be corrected or reworded without unnecessary propositions.
+This does, however, **not** exempt you from the repository's rule set.
+
+## Pull requests
+
+### Naming
+
+The pull request should briefly and simply explain what it changes.
+It should be followed by the following format to show the SM and date ` - SM#X 20XX - 20XX-XX-XX`.
+For example:
+
+- `Add vice JML president role - SM#1 2025 - 2025-01-20`
+- `Update §5.3.3 discharge to 6 months - SM#5 2023/SM#1 2024 - 2023-12-05/2024-01-23` if it has been voted on twice.
+
+### Labeling
+
+Always assign the related labels to the PR.
+This includes if the statutes, memos or if it includes editorial changes.
+This is to more easily see which PR has changed what types of files.
+
+To be able to label the PR, you might need specific access to the repository.
+Therefore, those who have it need to add these labels if they are missing.
+
+### Reviewing
+
+It's highly recommended that someone reviews your PR before it gets merged.
+Small errors might not be found for years and can be hard to track down whether they were intended or not.
+
+Every time something has been voted to be changed with a proposition or a motion at a chapter meeting, the revision date of the affected documents needs to be changed.
+This is often missed, so always double-check this before merging.
+
+### Mergning
+
+All pull requests **must** be merged _in chronological order_ of the dates they got approved by a chapter meeting.
+If multiple pull requests were voted on at the same chapter meeting, the internal order is not important.
+
+In order for a PR to be merged, it needs to be approved by the chapter meeting.
+
+There are formatting rules to follow for this repository that will be checked on every PR automatically.
+These are in place to find blatant errors.
+However, some things might slip through and they are not super strict, so you always need to double-check your work.
+
+1. One sentence per line, to make it easier to refer to specific sentences.
+2. Do **not** break single sentences onto multiple lines.
+3. All files should have a trailing newline to prevent unnecessary whitespace commit changes.
+4. Memos should start with formalia sections:
+   - Purpose
+   - History
+   - Revising this Memo
+5. Only use normal quotation marks, avoid specially formatted opening and closing quotes.
+6. The Swedish and English files should match.
+   - Same dates in both files.
+   - Same number of lines.
+   - Same header numbering.
+
+## Releases
+
+As mentioned in the [README](../README.md) repository rules, all changes will be automatically built to the repository's releases.
+As a secretary, you should manage these releases.
+If multiple PRs have been merged, only keep the last one for each SM.
+Label the release with the SM and year the changes originate from.
+Update the text, explaining what has changed.
+
+- Include the following in the release:
+  - SM Protocol
+  - Changes
+  - Editorial Changes (if any)
+  - Pull Requests (linked and named)
+
+As a secretary, you can also create a custom named tag for the release.
+This allows everyone to easily find a previous state of the repository.
+These tags should be named `20XX-SMX`, like `2025-SM3`.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,6 +1,19 @@
-## Changes
+<!--
+###### Pull Request Title Format ######
 
-Summarize what this pull request changes. Specify if it's **editorial** or a **memo/statutes update**.
+Always suffix the pull request title with the following, if the changes have been voted on at a chapter meeting:
+
+- Single meeting: " - SM#X 20YY - 20YY-MM-DD"
+- Multiple meetings: " - SM#X 20YY/SM#X 20YY - 20YY-MM-DD/20YY-MM-DD"
+
+Example: "Update chapter logo in Memo for Graphical Profile - SM#1 2026 - 2026-04-12"
+-->
+
+# Changes
+
+<!--Summarize what this pull request changes.-->
+
+<!--Specify if it's editorial or a memo/statutes update.-->
 
 ## Documents
 
@@ -8,26 +21,12 @@ Proposition/Motion:
 
 Signed Protocol:
 
-## Reminders
+<!--
+###### Reminders ######
 
 Before submitting, please ensure:
-
-- [ ] Link the all relevant files and the signed protocol(s)
-- [ ] Update revision dates in the documents (if applicable)
-- [ ] One sentence per line only
-- [ ] Do not break single sentences onto multiple lines
-
-### Pull Request Title Format
-
-Always suffix the pull request title with the following, if the changes have been voted on at a chapter meeting:
-
-- Single meeting: ` - SM#X 20YY - 20YY-MM-DD`
-- Multiple meetings: ` - SM#X 20YY/SM#X 20YY - 20YY-MM-DD/20YY-MM-DD`
-
-Example: `Update chapter logo in Memo for Graphical Profile - SM#1 2026 - 2026-04-12`
-
-### Merge & Commit Message
-
-_Maintainers will merge this pull request using squash and merge with the following commit message format prefix, if the changes have been voted on at a chapter meeting: `SMX 20YY-<changes>`_
-
-_All merges will be merged in chronological order of the dates they got approved by a chapter meeting._
+- Link the all relevant files and the signed protocol(s) above
+- Update revision dates in the documents (if applicable)
+- Only one sentence per line
+- Do not break single sentences onto multiple lines
+-->

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,9 @@
+## Changes
+
+Summarize what this PR changes and if its editorial or not.
+
+## Documents
+
+Proposition/Motion:
+
+Signed Protocol:

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,9 +1,33 @@
 ## Changes
 
-Summarize what this PR changes and if its editorial or not.
+Summarize what this pull request changes. Specify if it's **editorial** or a **memo/statutes update**.
 
 ## Documents
 
 Proposition/Motion:
 
 Signed Protocol:
+
+## Reminders
+
+Before submitting, please ensure:
+
+- [ ] Link the all relevant files and the signed protocol(s)
+- [ ] Update revision dates in the documents (if applicable)
+- [ ] One sentence per line only
+- [ ] Do not break single sentences onto multiple lines
+
+### Pull Request Title Format
+
+Always suffix the pull request title with the following, if the changes have been voted on at a chapter meeting:
+
+- Single meeting: ` - SM#X 20YY - 20YY-MM-DD`
+- Multiple meetings: ` - SM#X 20YY/SM#X 20YY - 20YY-MM-DD/20YY-MM-DD`
+
+Example: `Update chapter logo in Memo for Graphical Profile - SM#1 2026 - 2026-04-12`
+
+### Merge & Commit Message
+
+_Maintainers will merge this pull request using squash and merge with the following commit message format prefix, if the changes have been voted on at a chapter meeting: `SMX 20YY-<changes>`_
+
+_All merges will be merged in chronological order of the dates they got approved by a chapter meeting._

--- a/other_documents/eng/asiktsdokument_for_in_sektionen.md
+++ b/other_documents/eng/asiktsdokument_for_in_sektionen.md
@@ -58,14 +58,14 @@ Därför behöver den antingen ersättas eller kompletteras med annan typ av exa
 Därtill är det viktigt att inse att betygssättning vid tillämpande av målrelaterade betyg oftast inte kan översättas till att ett vist antal rätt på en tentamen ger ett visst betyg.  
 För det andra så måste även undervisningen i kursen anpassas så att den kan nå de mål som ställts upp.  
 Detta kan kanske ses som självklart men då utbildningen på KTH ofta bygger på föreläsningar och självständiga studier utefter en kursbok så är denna självklarhet långt ifrån en realitet i utbildningen.  
-Moment så som laborationer, projektarbetet, seminarier etc.   bör med andra ord uppmuntras.  
+Moment så som laborationer, projektarbetet, seminarier etc. bör med andra ord uppmuntras.  
 En fördel med detta är också att dessa moment i utbildningen även kan
 användas i examinerande syfte.  
 Flertalet kurser är redan anpassats till detta men fortfarande finns många kurser som ännu inte börjat tillämpa detta tänkande.
 
 **Sektionen för Infromationsteknik anser att:**
 
-- betygssättning på KTH skall vara målrelaterad.  
+- betygssättning på KTH skall vara målrelaterad.
 - examination av kurser skall utformas så att dessa kan mäta de mål som är uppställda för kursen.
 - I kurser där mål inte examineras bör antingen mål eller examination omformas.
 - andra examinationsformer än skriftlig salstentamen bör uppmuntras.

--- a/other_documents/eng/direktiv_strangar.md
+++ b/other_documents/eng/direktiv_strangar.md
@@ -1,25 +1,25 @@
-# Direktiv för Strängteoretiquerna
+# Directive for Strängteoretiquerna
 
-## 1 Formalia
+## 1 Formalities
 
-### 1.1 Syfte
+### 1.1 Purpose
 
-Detta direktiv är avsett att reglera klubben Strängteoretiquerna.
+This directive is intended to regulate the club Strängteoretiquerna.
 
-Strängteoretiquerna är en klubb tillhörande Sektionen för Informationsteknik som syftar till att främja bevarande och skapande av studentqultur.
+Strängteoretiquerna is a club belonging to the Chapter for Information Technology that aims to promote the preservation and creation of student culture.
 
-### 1.2 Historik
+### 1.2 History
 
-Upprättat: 2014-06-06  
-Senast ändrat: 2024-12-03
+Established: 2014-06-06
+Last revision: 2024-12-03
 
-## 2 Organisation
+## 2 Organization
 
-Strängteoretiquerna leds av de två språkrören Bellman och Fredman.  
-Dessa två godkänns av sektionsmötet.
+Strängteoretiquerna are led by the two spokesmen Bellman and Fredman.
+These two are approved by the chapter meeting.
 
-## 3 Verksamhet
+## 3 Activities
 
-Strängteoretiquernas verksamhet regleras under eget reglemente vilket är en del av denna PM.
+Strängteoretiquerna activities are regulated under their own regulations, which are part of this PM.
 
-Detta reglemente ändras i enlighet med bestämmelser i nämnda reglemente.
+These regulations are amended in accordance with the provisions of the aforementioned regulations.

--- a/other_documents/eng/visionsplan.md
+++ b/other_documents/eng/visionsplan.md
@@ -10,7 +10,7 @@ The goals shall act as a guide for the chapter's work.
 - All students at KTH Kista feles personally welcome and appriciated in the chapter.
 - All students at KTH Kista benefit from the chapter.
 - All students at KTH Kista have a sense of belonging to the chapter, THS, and KTH.
-- All chapter members has a good time during their spare time when they are not studying.  
+- All chapter members has a good time during their spare time when they are not studying.
   Nobody should sit at home and be involontarily bored but there should always be a fun event they can attend.
 - All chapter members know what the chapter does and is working towards.
 

--- a/other_documents/swe/asiktsdokument_for_in_sektionen.md
+++ b/other_documents/swe/asiktsdokument_for_in_sektionen.md
@@ -58,14 +58,14 @@ Därför behöver den antingen ersättas eller kompletteras med annan typ av exa
 Därtill är det viktigt att inse att betygssättning vid tillämpande av målrelaterade betyg oftast inte kan översättas till att ett vist antal rätt på en tentamen ger ett visst betyg.  
 För det andra så måste även undervisningen i kursen anpassas så att den kan nå de mål som ställts upp.  
 Detta kan kanske ses som självklart men då utbildningen på KTH ofta bygger på föreläsningar och självständiga studier utefter en kursbok så är denna självklarhet långt ifrån en realitet i utbildningen.  
-Moment så som laborationer, projektarbetet, seminarier etc.   bör med andra ord uppmuntras.  
+Moment så som laborationer, projektarbetet, seminarier etc. bör med andra ord uppmuntras.  
 En fördel med detta är också att dessa moment i utbildningen även kan
 användas i examinerande syfte.  
 Flertalet kurser är redan anpassats till detta men fortfarande finns många kurser som ännu inte börjat tillämpa detta tänkande.
 
 **Sektionen för Infromationsteknik anser att:**
 
-- betygssättning på KTH skall vara målrelaterad.  
+- betygssättning på KTH skall vara målrelaterad.
 - examination av kurser skall utformas så att dessa kan mäta de mål som är uppställda för kursen.
 - I kurser där mål inte examineras bör antingen mål eller examination omformas.
 - andra examinationsformer än skriftlig salstentamen bör uppmuntras.

--- a/other_documents/swe/direktiv_hattar.md
+++ b/other_documents/swe/direktiv_hattar.md
@@ -2,31 +2,31 @@
 
 ## 1. Formalia
 
-### 1.1 Syfte  
+### 1.1 Syfte
 
 Detta direktiv är avsett att reglera hattklubben *hattklubben*.  
-Hattklubben arbetar för att främja bärandet av hattar bland sektionens medlemmar.  
+Hattklubben arbetar för att främja bärandet av hattar bland sektionens medlemmar.
 
-### 1.2 Historik  
+### 1.2 Historik
 
 Upprättat: 2013-10-23  
 Senast ändrat: 2013-10-23
 
-## 2. Organisation  
+## 2. Organisation
 
-### 2.1 Hattklubbens ordförande  
+### 2.1 Hattklubbens ordförande
 
 Hattklubbens ordförande är den av hattklubbens medlemmar som för tillfället bär flest hattar.
 
-### 2.2 Medlemskap  
+### 2.2 Medlemskap
 
 För att bli medlem i hattklubben krävs det att man är sektionsmedlem samt bär minst en (1) hatt.  
 Medlemskapet är giltigt så länge medlemmen bär minst en (1) hatt.
 
-## 3. Hattar  
+## 3. Hattar
 
 Hattklubben definierar en hatt med avseende på medlemskap samt ordförandeskap som ett föremål som bärs på ett huvud
 
-## 4. Motto  
+## 4. Motto
 
-Hattklubbens motto är och skall förbli *”Hattar när det händer”*.
+Hattklubbens motto är och skall förbli *"Hattar när det händer"*.

--- a/other_documents/swe/visionsplan.md
+++ b/other_documents/swe/visionsplan.md
@@ -10,7 +10,8 @@ Målen ska användas som vägledning i sektionens arbete.
 - Alla studenter i KTH Kista känner sig personligen välkomna och uppskattade i IT-Sektionen.
 - Alla studenter i KTH Kista har nytta av sektionen.
 - Alla studenter i KTH Kista känner tillhörighet till IT-Sektionen, THS och KTH.
-- Alla sektionsmedlemmar har kul på sin fritid när de inte studerar. Ingen ska sitta hemma och ha ofrivilligt tråkigt, utan det finns alltid ett roligt event hen kan gå på!
+- Alla sektionsmedlemmar har kul på sin fritid när de inte studerar.
+  Ingen ska sitta hemma och ha ofrivilligt tråkigt, utan det finns alltid ett roligt event hen kan gå på!
 - Alla medlemmar i IT-Sektionen vet vad sektionen gör och verkar för
 
 ## Aktiva medlemmar

--- a/pm/eng/00_pm_for_pm.md
+++ b/pm/eng/00_pm_for_pm.md
@@ -85,4 +85,4 @@ Memo for the Chapter Board, 2008-12-11
 Memo for the Chapter Standard, 2011-12-08  
 Memo for the Chapter's Locals, 2008-12-11  
 Memo for the Chapter's Profile, 2014-02-10  
-Memo for the Elections Committee, 2014-02-10  
+Memo for the Elections Committee, 2014-02-10

--- a/pm/eng/pm_for_fortroendevalda_positioner.md
+++ b/pm/eng/pm_for_fortroendevalda_positioner.md
@@ -8,7 +8,7 @@ The purpose of this Memo is to list all of the chapter's trustee elected positio
 
 ### 1.2 History
 
-Created: 2021-11-29  
+Established: 2021-11-29  
 Last revision: 2025-01-20
 
 ### 1.3 Revising this Memo
@@ -56,7 +56,7 @@ The list may be changed without decisions at SM, where after SM decides on chang
 
 - vice President
 - Responsible for Kista Arbetsmarknadsdag (KAM)
- 
+
 #### 2.2.5 Communications Committee
 
 - vice President
@@ -102,7 +102,7 @@ The list may be changed without decisions at SM, where after SM decides on chang
 
 - Convener
 - Member - at least 4
-  
+
 #### 2.2.13 JML
 
 - vice President

--- a/pm/eng/pm_for_grafisk_profil.md
+++ b/pm/eng/pm_for_grafisk_profil.md
@@ -4,14 +4,14 @@
 
 ### 1.1 Purpose
 
-The purpose of this memo is to define how documents and other material from the chapter looks, to ensure that it is clear that the chapter is the sender, and to formalise the chapter’s attributes and how these may and shall be used.  
+The purpose of this memo is to define how documents and other material from the chapter looks, to ensure that it is clear that the chapter is the sender, and to formalise the chapter's attributes and how these may and shall be used.
 
-The material being produced shall be uniform in nature, and the chapter’s attributes may not be wrongfully used.
+The material being produced shall be uniform in nature, and the chapter's attributes may not be wrongfully used.
 
 ### 1.2 History
 
 Established: 2017-05-23  
-Changed: 2025-06-08
+Last revision: 2025-06-08
 
 ### 1.3 Revising this Memo
 
@@ -28,32 +28,30 @@ However, it is strongly recommended that the committees apply §2.2 and §3 on t
 
 ## 2 Logotype
 
-The chapter’s logotype is defined in the Memo for Insignia.
+The chapter's logotype is defined in the Memo for Insignia.
 
 ### 2.1 Colorization
 
-The legs of the microchip shall be of the color laser violet (`#CC99FF`, see
-§1.2 in the chapter's statutes) and the centrum shall have a darker tone of
-the same color (for example `#403050`).
+The legs of the microchip shall be of the color laser violet (`#CC99FF`, see §1.2 in the chapter's statutes) and the centrum shall have a darker tone of the same color (for example `#403050`).
 The lightning bolt shall be white (`#FFFFFF`).
 
 In the case that the official emblem cannot be displayed without difficulties there is two monochrome variants of the emblem to use, one white and one black.  
 In the monochrome version the legs of the microchip have the same color as the lightning bolt, while the centrum is void of color.  
 The monochrome emblems can for example be used in print, on clothes, or posters.
 
-The chapter’s logotype may not be broken apart, and the fully colored logotype may not be colored in any other way, or with other colors than those defined above.  
+The chapter's logotype may not be broken apart, and the fully colored logotype may not be colored in any other way, or with other colors than those defined above.  
 The monochrome logotypes may be colored in other colors than those defined above, given that all elements of the logotype are of the same color.
 
 ### 2.2 Usage
 
-For posters and the like the logotype shall be placed in one of the poster’s corners, in accordance with the provided templates and defined proportions.
+For posters and the like the logotype shall be placed in one of the poster's corners, in accordance with the provided templates and defined proportions.
 
 If the logotype is used together with THS' logotype, it should be placed in the opposite corner.
 
 Use the monochrome logotypes if the colored logotype is not sufficiently visible against a background.  
 When using the monochrome logotypes, the white logotype shall be used if the back-ground is dark, and the black if the background is light.
 
-The distance to other elements must be at least a quarter of the logotype’s width, on all sides.
+The distance to other elements must be at least a quarter of the logotype's width, on all sides.
 
 The chapter's name "Sektionen för Informationsteknik", in English "The Chapter for Information Technology" and the abbreviations "IT-Sektionen" and "IT-Chapter" is allowed to be closer to the logotype, but should be with the distance of b1 (the width of the top triangle or one eight of the logos width).
 

--- a/pm/eng/pm_for_idrottsnamnden.md
+++ b/pm/eng/pm_for_idrottsnamnden.md
@@ -10,7 +10,7 @@ The purpose of the Sports Committee is to encourage physical activities in the c
 
 ### 1.2 History
 
-Created: 2008-12-11  
+Established: 2008-12-11  
 Last revision: 2022-09-27
 
 ### 1.3 Revising this Memo

--- a/pm/eng/pm_for_information.md
+++ b/pm/eng/pm_for_information.md
@@ -8,7 +8,7 @@ The purpose of this memo is to regulate the chapter's official channels for info
 
 ### 1.2 History
 
-Created: 2008-12-11  
+Established: 2008-12-11  
 Last revision: 2025-04-22
 
 ### 1.3 Revising this Memo
@@ -17,20 +17,19 @@ In order to pass a revision of this Memo, a decision has to be made with a quali
 
 ## 2 Official channels for information
 
-- The chapter's website, [https://kth.it](https://kth.it)  
+- The chapter's website, [https://kth.it](https://kth.it)
 - Mailing lists via e-mail for chapter meetings.
   Any other dispatches via e-mail must be approved the the chapter's board.
 - Posts on the IT-Chapter's Instagram and Discord.
 
 ## 3 Practices for information
 
-- A sender’s signature shall make it clear who they are.
+- A sender's signature shall make it clear who they are.
 - Information aimed at all members shall be available in both english and swedish.
-- All trustees with a mail account for their position shall in all correspondence regarding the chapter’s activities use this mail account to the greatest extent
-possible.
+- All trustees with a mail account for their position shall in all correspondence regarding the chapter's activities use this mail account to the greatest extent possible.
 - Information about chapter and board meetings shall be posted in advance on Discord, Instagram and the chapter's website.
 
 ## 4 Rules for use of programme mailing lists
 
 - In the subject it shall be clear that the mail refers to chapter activities.  
-  For example by including IT-Sektionen in the title according to the format “`IT-Sektionen | <title>`”.
+  For example by including IT-Sektionen in the title according to the format "`IT-Sektionen | <title>`".

--- a/pm/eng/pm_for_insignia.md
+++ b/pm/eng/pm_for_insignia.md
@@ -8,7 +8,7 @@ The purpose of this memo is to regulate the chapter's insignia.
 
 ### 1.2 History
 
-Created: 2013-10-16  
+Established: 2013-10-16  
 Last revision: 2025-06-08
 
 ### 1.3 Revising this Memo
@@ -19,21 +19,17 @@ To change this memo a decision needs to be made with qualified majority on two c
 
 ### 2.1 Official Emblem
 
-The chapter's logotype is distinguished by the letters I and T as two
-parts of a vertical lightning bolt, where the I is resting on top of the T. The
-lone bolt shall be of the color laser violet (`#CC99FF`, see §1.2 in the chapter’s
-statues). In cases where the flash cannot be used without difficulty, it
-should be encompassed in a 45 degree tilted square that depicts a stylized
+The chapter's logotype is distinguished by the letters I and T as two parts of a vertical lightning bolt, where the I is resting on top of the T.
+The lone bolt shall be of the color laser violet (`#CC99FF`, see §1.2 in the chapter's statues).
+In cases where the flash cannot be used without difficulty, it should be encompassed in a 45 degree tilted square that depicts a stylized
 microchip.
 
 The official logotype looks like this:
 
 ![The chapter's logo, in color](./img/logo-it-1500px.png)
 
-The legs of the microchip shall be of the color laser violet (`#CC99FF`, see
-§1.2 in the chapter's statutes) and the centrum shall have a darker tone of
-the same color (for example `#403050`). The lightning bolt shall be white
-(`#FFFFFF`).
+The legs of the microchip shall be of the color laser violet (`#CC99FF`, see §1.2 in the chapter's statutes) and the centrum shall have a darker tone of the same color (for example `#403050`).
+The lightning bolt shall be white (`#FFFFFF`).
 
 ### 2.2 Monochrome Emblem
 

--- a/pm/eng/pm_for_iterativa_klubben.md
+++ b/pm/eng/pm_for_iterativa_klubben.md
@@ -9,7 +9,7 @@ The purpose of the ITerative Club is to arrange events for the chapter's members
 
 ### 1.2 History
 
-Created: 2008-12-11  
+Established: 2008-12-11  
 Last revision: 2023-12-05
 
 ### 1.3 Revising this Memo
@@ -24,7 +24,7 @@ They are approved by the chapter meeting.
 ITerative Club's budget is managed by the Bureaucracy Senator.  
 Approved by the chapter meeting.
 
-Other committee board members are elected according to the committee's regulations.  
+Other committee board members are elected according to the committee's regulations.
 
 Interested members of the chapters may become members of the ITerative Club.
 

--- a/pm/eng/pm_for_jml.md
+++ b/pm/eng/pm_for_jml.md
@@ -10,7 +10,7 @@ The JML committee is also responsible for furthering the integration and engagem
 
 ### 1.2 History
 
-Created: 2022-11-28  
+Established: 2022-11-28  
 Last revision: 2025-01-20
 
 ### 1.3 Revising this Memo
@@ -34,27 +34,26 @@ The JML committee includes:
 
 ### 2.2 Appointment
 
-All board representatives of the chapter's JML committee are elected by the Chapter Meeting.  
+All board representatives of the chapter's JML committee are elected by the Chapter Meeting.
 
-The members of the JML-workgroup can be appointed by the Board Member responsible for JML and the Vice chairperson of the Board of the JML Committee.
-
-The members of the International workgroup can be appointed by the Board of the JML Committee.
+The members of the JML-workgroup are appointed by the Board Member responsible for JML and the Vice chairperson of the Board of the JML Committee.
+The members of the International workgroup are appointed by the Board of the JML Committee.
 
 ## 3 Individual responsibility
 
 ### 3.1 Board Member responsible for JML
 
-The Board Member responsible for JML are responsible for running the chapter's JML work and to be the convening responsible and leader of the JML-workgroup.  
+The Board Member responsible for JML are responsible for running the chapter's JML work and to be the convening responsible and leader of the JML-workgroup.
 
 These tasks include:
 
-- To spread the knowledge and understanding of JML within the chapter to its members.  
-- To inform the chapter's members of the JML work that is being conducted.  
-- To help chapter members in JML matters according to the chapter's course of action plan titled "Planned course of action in JML matters".  
-- To take part in the Train-the-Trainer education given by the KTH equality office with one or more members from the Studie social committee.  
-- To hold and arrange a JML workshop for new students during the reception.  
-- To hold and arrange a JML workshop for those that participate in the reception of new students.  
-- To hold and arrange a JML workshop so the chapter board and those holding a trustee position within the chapter has the opportunity to participate once during their elected term.  
+- To spread the knowledge and understanding of JML within the chapter to its members.
+- To inform the chapter's members of the JML work that is being conducted.
+- To help chapter members in JML matters according to the chapter's course of action plan titled "Planned course of action in JML matters".
+- To take part in the Train-the-Trainer education given by the KTH equality office with one or more members from the Studie social committee.
+- To hold and arrange a JML workshop for new students during the reception.
+- To hold and arrange a JML workshop for those that participate in the reception of new students.
+- To hold and arrange a JML workshop so the chapter board and those holding a trustee position within the chapter has the opportunity to participate once during their elected term.
 - To lead the preventive work according to the Memo for Conduct of Conduct.
 - To inform the chapter members about the PM for Conduct of Conduct.
 
@@ -79,7 +78,9 @@ The tasks of the International-coordinator includes:
 
 ### 3.5 International workgroup
 
-Tasked to work with promoting the position, integration, and engagement of international students in the chapter under the International Coordinator. Members of the group that have actively contributed for a total of 25 working hours within a 4 month period, are eligible for a 0.2 GPA boost for exchange studies up to the discretion of the THS Head of International and the International Coordinator.
+Tasked to work with promoting the position, integration, and engagement of international students in the chapter under the International Coordinator.
+They also work together with the International Coordinator and the Reception Committee to ensure that events are planned and implemented for all new master's students and exchange students who begin their studies and who will belong to the section during their studies at KTH.
+Members of the group that have actively contributed for a total of 25 working hours within a 4 month period, are eligible for a 0.2 GPA boost for exchange studies up to the discretion of the THS Head of International and the International Coordinator.
 
 ## 4 Logo
 

--- a/pm/eng/pm_for_kommunikationsnamnden.md
+++ b/pm/eng/pm_for_kommunikationsnamnden.md
@@ -10,7 +10,7 @@ The purpose of the Communication Committee is to coordinate communication, flow 
 
 ### 1.2 History
 
-Created: 2014-01-01  
+Established: 2014-01-01  
 Last revision: 2023-12-05
 
 ### 1.3 Revising this Memo
@@ -43,10 +43,10 @@ The vice chairperson is also responsible for the work delegated to them by the c
 
 ### 2.3 History Responsible
 
-The History Responsible shall document and bring the Chapter’s history to life in such a way that all future chapter activities can make use of it, and all chapter members can take part of it.
+The History Responsible shall document and bring the Chapter's history to life in such a way that all future chapter activities can make use of it, and all chapter members can take part of it.
 
 The History Responsible person is headresponsible for keeping in contact with the Chapter's alumni.  
-This includes informing them of events that may be of interest to them and to create opportunities for the Chapter’s members to make contact with said alumni.
+This includes informing them of events that may be of interest to them and to create opportunities for the Chapter's members to make contact with said alumni.
 
 The History Responsible person shall see that all the committees maintain their part of the PM of traditions and shall themselves take responsibility to preserve the Chapter´s overall traditions.
 
@@ -56,20 +56,20 @@ The History Responsible person shall see that all the committees maintain their 
 
 The committee for communication is responsible for:
 
-- that information about the chapter's activities is published on the chapter's official website and other channels for communication where the chapter has an official presence.  
-- that in mutual agreement with the chapter's other committees help them to more efficiently reach the chapter's member.  
-- to receive and process requests and opinions regarding the chapter's website and other channels for communication.  
-- to carry out the operation of the website and mail accounts linked to the chapter' domain(s).  
+- that information about the chapter's activities is published on the chapter's official website and other channels for communication where the chapter has an official presence.
+- that in mutual agreement with the chapter's other committees help them to more efficiently reach the chapter's member.
+- to receive and process requests and opinions regarding the chapter's website and other channels for communication.
+- to carry out the operation of the website and mail accounts linked to the chapter' domain(s).
 - to coordinate web developers for larger development or maintenance projects that can not be carried out by the committee.
 
 ### 3.2 Profile
 
 The committee for communication is responsible for:
 
-- that overalls that are in accordance with "the Chapter's documents for profile" are procured and sold  
-- that profile items are procured and sold  
-- that requests by the members about profile items are processed and evaluated, by surveys in cooperation with other members of the committee  
-- to help the chapter's committees with graphical material, such as posters, if needed in the committees activities  
+- that overalls that are in accordance with "the Chapter's documents for profile" are procured and sold
+- that profile items are procured and sold
+- that requests by the members about profile items are processed and evaluated, by surveys in cooperation with other members of the committee
+- to help the chapter's committees with graphical material, such as posters, if needed in the committees activities
 - to make clear the chapter's connection to THS
 
 ### 3.3 Alumni
@@ -78,8 +78,8 @@ History Responsible is responsible for the chapter's contact with the school's a
 
 The responsibilities include:
 
-- to be a contact person for communication between the chapter and the alumni members  
-- to inform the alumni members about those events in the chapter that may be of interest in them  
+- to be a contact person for communication between the chapter and the alumni members
+- to inform the alumni members about those events in the chapter that may be of interest in them
 - to arrange events where the chapter's members can meet and network with alumni members, such as alumni pubs
 
 ## 4 Economy

--- a/pm/eng/pm_for_mottagningsnamnden.md
+++ b/pm/eng/pm_for_mottagningsnamnden.md
@@ -8,7 +8,7 @@ The purpose of this memo is to regulate the Reception Committee
 
 ### 1.2 History
 
-Created: 2008-12-11  
+Established: 2008-12-11  
 Last revision: 2024-11-11
 
 ### 1.3 Revising this Memo

--- a/pm/eng/pm_for_naringslivsnamnden.md
+++ b/pm/eng/pm_for_naringslivsnamnden.md
@@ -10,7 +10,7 @@ The purpose of the Business Relations Committee is to market and promote the cha
 
 ### 1.2 History
 
-Created: 2008-12-11  
+Established: 2008-12-11  
 Last revision: 2022-09-27
 
 ### 1.3 Revising this Memo
@@ -21,7 +21,7 @@ In order to pass a revision of this Memo, a decision has to be made with a quali
 
 The board of the Business Relations Committee is made up by:
 
-- Board member responsible for Business Relations  
+- Board member responsible for Business Relations
 - Deputy chairperson
 
 These are elected by the chapter meeting.
@@ -47,9 +47,9 @@ The deputy chairperson is also responsible for the work delegated to them by the
 
 The Business Relations Committee is responsible for:
 
-- contacting and staying in touch with companies regarding company events and activities  
-- arranging events based on what is requested and agreed upon based on the previous point  
-- to evaluate events that has been carried out and collect feedback from both students and companies  
+- contacting and staying in touch with companies regarding company events and activities
+- arranging events based on what is requested and agreed upon based on the previous point
+- to evaluate events that has been carried out and collect feedback from both students and companies
 - to arrange and host Kista Arbetsmarknadsdag (KAM) during the school year
 
 ### 3.2 Sponsorship

--- a/pm/eng/pm_for_piff_och_puff.md
+++ b/pm/eng/pm_for_piff_och_puff.md
@@ -8,7 +8,7 @@ The purpose of this Memo is to regulate the committee *PIFF och PUFF*.
 
 ### 1.2 History
 
-Created: 2020-09-28  
+Established: 2020-09-28  
 Last revision: 2020-09-28
 
 ### 1.3 Revising this Memo
@@ -57,6 +57,8 @@ The nomination is based on an audition where all chapter members may participate
 All members of the faction have the right to attend the audition, and state their opinion about the suitability of any candidates.
 
 In the event that a faction is missing a president, or that the president is seeking to be reelected, the active members of the faction are responsible for conducting the process.
+
+The nominated person is approved by the chapter meeting.
 
 ### 3.2 Election of Active Faction Members
 

--- a/pm/eng/pm_for_sektionens_profil.md
+++ b/pm/eng/pm_for_sektionens_profil.md
@@ -2,7 +2,7 @@
 
 ## 1 Formalities
 
-## 1.1 Purpose
+### 1.1 Purpose
 
 The purpose of this memo is to clearify the guildelines regarding the member's of the chapter of Information Technology's overalls and the chapter's other profile items.
 
@@ -44,11 +44,11 @@ The stripe does not have to be replaced if the student switches programs,this is
 
 #### 2.2.2 Color
 
-- Students attending the program Civilingenjörsutbildning med inriktning Informationsteknik shall wear laser violet leg stripes.  
-- Students attending the program Civilingenjörsutbildning med inriktning Mikroelektronik shall wear lime green leg stripes.  
-- Students attending the program Högskoleingenjörsutbildning med inriktning Elektronik och datorteknik shall wear white leg stripes.  
-- Students attending the program Högskoleingenjörsutbildning med inriktning Datateknik shall wear cerise leg stripes.  
-- Students attending the program Kandidatutbildning med inriktning Affärssystem shall wear cerise and porter brown leg stripes.  
+- Students attending the program Civilingenjörsutbildning med inriktning Informationsteknik shall wear laser violet leg stripes.
+- Students attending the program Civilingenjörsutbildning med inriktning Mikroelektronik shall wear lime green leg stripes.
+- Students attending the program Högskoleingenjörsutbildning med inriktning Elektronik och datorteknik shall wear white leg stripes.
+- Students attending the program Högskoleingenjörsutbildning med inriktning Datateknik shall wear cerise leg stripes.
+- Students attending the program Kandidatutbildning med inriktning Affärssystem shall wear cerise and porter brown leg stripes.
 - Students attending the program kandidatutbildning med inriktning Informations- och kommunikationsteknik shall wear laser violet leg stripes.
 
 #### 2.2.3 Old overalls

--- a/pm/eng/pm_for_sektionens_styrelse.md
+++ b/pm/eng/pm_for_sektionens_styrelse.md
@@ -8,8 +8,8 @@ The purpose of this Memo is to formulate and to regulate the chapter's Board's c
 
 ### 1.2 History
 
-Created: 2008-12-11  
-Senast ändrat: 2022-11-28
+Established: 2008-12-11  
+Last revision: 2022-11-28
 
 ### 1.3 Revising this Memo
 
@@ -31,7 +31,6 @@ The Chapter's board is composed of:
 - Board member responsible for Communication
 - Board member responsible for JML Activities
 - Board member
-- Chapter vice Cashier
 
 ### 2.2 Deputies
 
@@ -83,7 +82,7 @@ The vice president shall maintain close contact to the representatives in the re
 #### 3.2.3 Secretary
 
 The secretary is responsible for the chapter's documents.  
-They shall be well-read on the chapter statutes and Memos and shall make sure that it is correctly written both in meaning and language.  
+They shall be well-read on the chapter statutes and Memos and shall make sure that it is correctly written both in meaning and language.
 
 The secretary shall act as a support for any chapter member that wishes to make a motion.
 
@@ -99,7 +98,7 @@ The treasurer shall actively cooperate with and attend meetings arranged by THS 
 
 #### 3.2.5 Board member responsible for education influence
 
-The Board member responsible for education influence shall work long-term and strategically with educational, equality, and diversity questions within the programs connected to the chapter and shall work towards their constant improvement until their best possible state is achieved.  
+The Board member responsible for education influence shall work long-term and strategically with educational, equality, and diversity questions within the programs connected to the chapter and shall work towards their constant improvement until their best possible state is achieved.
 
 The board member is the convenor of the Education Committee and shall lead the operative work of the trustees within the committee.  
 The board member shall also be a support for said trustees and shall be a link between the board and The Education Committee.  

--- a/pm/eng/pm_for_sektionens_utrymmen.md
+++ b/pm/eng/pm_for_sektionens_utrymmen.md
@@ -35,8 +35,7 @@ The chapter board is responsible for communicating the authorization changes to 
 
 #### 2.1.3 Sharing
 
-In the event that several parts of the chapter shares the same space no one part may take up a disproportionally large portion of said space.  
-This also applies to temporary storage since temporary storage situations has a tendency to becomes permanent.
+In the event that several parts of the chapter shares the same space, no part may take up a disproportionally large portion of said space; not even for temporary storage (as temporary storage has a tendency to become permanent).
 
 #### 2.1.4 Connection to activities
 
@@ -49,7 +48,7 @@ Equipment and materials that is stored in any space may never be placed in such 
 #### 2.1.6 Storage containers
 
 All equipment and materials shall to the utmost extent be packaged, for example in boxes, nets or sacks.  
-"Borrowed" storage vessels that the part of the chapter does not own(e.g. Shopping carts) should not be used.
+"Borrowed" storage vessels that the part of the chapter does not own (e.g. shopping carts) should not be used.
 
 #### 2.1.7 Compliance
 
@@ -78,6 +77,6 @@ Studiemiljönämnden are responsible for maintaining the chapter hall's public s
 
 The chapters klubbmästerier are responsible for maintaining the bar, kitchen, and connected storage spaces.
 
-#### 3.2 Restoring spaces after use
+### 3.2 Restoring spaces after use
 
 The committee or person that have borrowed the chapter hall are responsible for restoring the chapter hall and all connected spaces in accordance with the current cleaning list.

--- a/pm/eng/pm_for_stickkontaktsansvarig.md
+++ b/pm/eng/pm_for_stickkontaktsansvarig.md
@@ -8,10 +8,10 @@ This memo formalises and regulates the honorary position of Stickkontaktsansvari
 
 ### 1.2 History
 
-Created: 2019-02-13  
+Established: 2019-02-13  
 Last revision: 2019-02-13
 
-### 1.3 Revising this memo
+### 1.3 Revising this Memo
 
 In order to pass a revision of this memo, a decision has to be made with a qualified majority at two subsequent chapter meetings.
 

--- a/pm/eng/pm_for_studiesociala_namnden.md
+++ b/pm/eng/pm_for_studiesociala_namnden.md
@@ -12,7 +12,7 @@ The Study Social Committee is responsible for developing student life within the
 Established: 2020-05-20  
 Last revision: 2024-11-11
 
-### 1.3 Revisions to this Memo
+### 1.3 Revising this Memo
 
 In order to pass a revision of this Memo a decision has to be made with a qualified majority on a Chapter meeting.
 

--- a/pm/eng/pm_for_traditioner.md
+++ b/pm/eng/pm_for_traditioner.md
@@ -41,7 +41,7 @@ An evening arranged by the KAM project group in order to make contacts between s
 ### 3.2 KAM: Kista Carreer Fair
 
 KAM is organized by the KAM project group in the Buisness Relations Committee with the purpouse of making connections betweend students in Kista and employers.  
-KAM is usually concluded with a banquet.
+KAM is usually concluded with a party.
 
 ## 4 QMISK
 
@@ -62,10 +62,9 @@ A gasque meant to end a study period and celebrate the finished exams.
 A trip for the active members of the reception.  
 Usually involves team buidling and a gasque.
 
-## 6.2 N0llegasque
+### 6.2 NØllegasque
 
-The grand closing of the reception.  
-Aimed at all persons related to the Reception, but mainly n0llan.
+The grand closing of the reception for all persons related to the Reception, but mainly nØllan.
 
 ## 7 ITK
 

--- a/pm/eng/pm_for_trygghetsrad.md
+++ b/pm/eng/pm_for_trygghetsrad.md
@@ -6,7 +6,7 @@
 
 This memo regulates the chapter's Council of Safety.
 
-### 1.2 Historik
+### 1.2 History
 
 Established: 2014-09-22  
 Last revision: 2025-04-22
@@ -30,7 +30,7 @@ The confidentiality can be extended to the chapter board when necessary.
 The chapters Council of Safety is responsible for
 
 - represent the chapter's members in questions regarding their working environment and to make sure that work assigned to trustees adheres to The Work Environment Act.
-- retain continual contact with THS' safety officer.  
+- retain continual contact with THS' safety officer.
 - retain continual contact with the chapter's representative in THS.
 
 ## 4 Regulations

--- a/pm/eng/pm_for_uppforande.md
+++ b/pm/eng/pm_for_uppforande.md
@@ -5,14 +5,14 @@
 ### 1.1 Purpose
 
 The purpose of this document is for the chapter to be an inclusive and safe environment for everyone.  
-Everyone has the right to be treated with respect and should feel welcome and safe at the chapter’s activities and in the chapter premises.
+Everyone has the right to be treated with respect and should feel welcome and safe at the chapter's activities and in the chapter premises.
 
 This Memo is part of the preventive work to avoid unacceptable behavior and to provide the chapter with a better basis to objectively handle situations where unacceptable behavior is exhibited.
 
 ### 1.2 History
 
 Established: 2023-12-05  
-Last Modified: 2023-12-05  
+Last revision:: 2023-12-05
 
 ### 1.3 Revising this Memo
 
@@ -20,7 +20,7 @@ In order to pass a revision of this Memo, a decision has to be made with a quali
 
 ### 1.4 Scope
 
-The policy must be followed by all chapter members and covers all participants in the chapter’s events, as well as in the representation of the chapter.
+The policy must be followed by all chapter members and covers all participants in the chapter's events, as well as in the representation of the chapter.
 
 This Memo should always be linked in all registration forms and event information.
 
@@ -55,7 +55,7 @@ Involved individuals in the investigation shall recuse themselves from cases whe
 It is not allowed to:
 
 - Violate personal boundaries that, with good reason, can be considered clearly set or if the person in question is noticeably uncomfortable.
-- Act deliberately exclusionary unless justified by the chapter’s or committees' governing documents.
+- Act deliberately exclusionary unless justified by the chapter's or committees' governing documents.
 - Express, write, or otherwise communicate offensive statements or messages in regards to an individual or identity.
   Identity includes, but is not limited to:
   - Gender
@@ -105,11 +105,11 @@ Chapter auditors are involved only if the parties involved feel that the case ha
 
 ### 5.1 Reporting
 
-A report can be made in case of a violation of this Memo through the chapter’s Council of Safety.
+A report can be made in case of a violation of this Memo through the chapter's Council of Safety.
 
 It is never too late to report previous violations of this Memo.
-
-An anonymous report can be made, and in such cases, no investigation takes place. Such a report contributes only to statistics and future preventive work.
+An anonymous report can be made, and in such cases, no investigation takes place.
+Such a report contributes only to statistics and future preventive work.
 
 A report against an Safety Officer should be made via private email to another Safety Officer or the chapter president and vice-president.
 The complainant always has the right to turn to another Safety Officer for support in the reporting process.
@@ -133,7 +133,7 @@ The victim can always choose to end an ongoing investigation.
 
 ### 5.3 Follow-up
 
-The Board promptly informs all parties involved and the chapter’s Council of Safety in writing, regardless of the outcome.
+The Board promptly informs all parties involved and the chapter's Council of Safety in writing, regardless of the outcome.
 
 Disclosure of information about decisions to trustee elected occurs in cases of suspensions and must be handled with care.
 Information is disclosed outside trustee elected only if necessary.

--- a/pm/eng/pm_for_valberedningen.md
+++ b/pm/eng/pm_for_valberedningen.md
@@ -2,7 +2,7 @@
 
 ## 1 Formalities
 
-## 1.1. Purpose
+### 1.1. Purpose
 
 Ths Memo regulates the Chapter's Elections Committee.
 
@@ -26,9 +26,9 @@ The purpose of this Memo is to formulate the Elections Committee's work and to m
 
 The Elections Committee shall
 
-- promote the elections that are administered during the current operational year  
-- collect nominations and candidacies  
-- interview the different candidates  
+- promote the elections that are administered during the current operational year
+- collect nominations and candidacies
+- interview the different candidates
 - make an official statement of opinion about the candidates and to act as a council for the chapter's decision.
 
 ## 4. Detailed Activities
@@ -59,7 +59,7 @@ The Elections Committee shall to the extent that it is possible conduct intervie
 
 The Elections Committee shall hand in a written opinion of each candidate to the decided upon chapter meeting.  
 In it the candidates qualities in relation to the position and any relevant differences between candidates shall be brought up.  
-The Elections Committee shall also include any other information that is relevant to the elections in the opinion.  
+The Elections Committee shall also include any other information that is relevant to the elections in the opinion.
 
 The Elections Committee shall favour the candidate or candidates that they deem are fit and decidedly better suited that any other potential candidates.  
 All candidates shall have access to the opinion about themselves and if they are favoured or not.  
@@ -82,9 +82,9 @@ It is of utmost importance this information be handled with care.
 
 All information about the candidates and the Elections Committees work is confidential and shall not be disclosed by the Elections Committee or any of it's members, except for these following exceptions:
 
-- Election minutes in accordance with the statements above, and any information the Election Committee provides the Chapter is public.  
+- Election minutes in accordance with the statements above, and any information the Election Committee provides the Chapter is public.
 - The Elections Committee shall, to the extent that it is relevant, answer the questions that are asked during chapter meetings.  
-  Any questions to any specific member of the Elections Committee may be left unanswered if it does not relate to a difference of opinion stated in the minutes.  
+  Any questions to any specific member of the Elections Committee may be left unanswered if it does not relate to a difference of opinion stated in the minutes.
 - Information that is deemed sensitive shall be provided to the chapter meeting if it is deemed important for the elections.  
   This must, however, be communicated to the relevant candidates who shall be given the chance to retract their candidacy.
 

--- a/pm/swe/00_pm_for_pm.md
+++ b/pm/swe/00_pm_for_pm.md
@@ -42,7 +42,7 @@ Första punkten i en PM skall heta "Formalia" och innehålla följande punkter:
 I punkten "Syfte" skall det framgå vad PM:n reglerar.  
 En PM får aldrig reglera något som inte har relevans till det syfte som PM:n har.
 
-I punkten "historik" skall datumet för upprättande samt datum för senaste ändring av PM finnas.
+I punkten "Historik" skall datumet för upprättande samt datum för senaste ändring av PM finnas.
 
 PM ändras med kvalificerad majoritet eller i enlighet med regler angivna i PM:et.
 

--- a/pm/swe/00_pm_for_pm.md
+++ b/pm/swe/00_pm_for_pm.md
@@ -34,15 +34,15 @@ Denna PM skall namnges så att det framgår vad som regleras.
 
 ### 2.3 Struktur
 
-Första punkten i en PM skall heta ”Formalia” och innehålla följande punkter:  
+Första punkten i en PM skall heta "Formalia" och innehålla följande punkter:  
 1.1 Syfte  
 1.2 Historik  
 1.3 Ändrande av PM
 
-I punkten “Syfte” skall det framgå vad PM:n reglerar.  
+I punkten "Syfte" skall det framgå vad PM:n reglerar.  
 En PM får aldrig reglera något som inte har relevans till det syfte som PM:n har.
 
-I punkten ”historik” skall datumet för upprättande samt datum för senaste ändring av PM finnas.
+I punkten "historik" skall datumet för upprättande samt datum för senaste ändring av PM finnas.
 
 PM ändras med kvalificerad majoritet eller i enlighet med regler angivna i PM:et.
 
@@ -85,4 +85,4 @@ PM för Studiesociala nämnden, 2020-05-20
 PM för Traditioner, 2014-12-08  
 PM för TraditionsMEsterIT, 2008-12-11  
 PM för Trygghetsråd, 2014-09-22  
-PM för Valberedningen, 2014-02-10  
+PM för Valberedningen, 2014-02-10

--- a/pm/swe/pm_for_grafisk_profil.md
+++ b/pm/swe/pm_for_grafisk_profil.md
@@ -44,7 +44,7 @@ Den monokroma logotypen får färgsättas i andra färger än de ovan angivna, f
 
 ### 2.2 Användning
 
-För affischer och dylikt skall logotypen vara placerad i ett av affischens hörn, i enlighet med de framtagna mallarna och rådande proportioner.  
+För affischer och dylikt skall logotypen vara placerad i ett av affischens hörn, i enlighet med de framtagna mallarna och rådande proportioner.
 
 Om logotypen används tillsammans med THS logotyp placeras den i det motsatta hörnet.
 

--- a/pm/swe/pm_for_information.md
+++ b/pm/swe/pm_for_information.md
@@ -17,7 +17,7 @@ För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet p�
 
 ## 2 Officiella informationskanaler
 
-- Sektionswebbplatsen, [https://kth.it](https://kth.it)  
+- Sektionswebbplatsen, [https://kth.it](https://kth.it)
 - Massutskick via e-post för SM.  
   Övriga utskick via e-post skall godkännas av sektionsstyrelsen.
 - Inlägg på IT-Sektionens Instagram and Discord
@@ -25,11 +25,11 @@ För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet p�
 ## 3 Informationspraxis
 
 - Avsändare ska framgå klart och tydligt genom sin signaturen.
-- Information riktad till samtliga medlemmar ska vara på engelska och svenska.  
+- Information riktad till samtliga medlemmar ska vara på engelska och svenska.
 - Alla funktionärer med funktionsmail ska i all mailkorrespondens gällande sektionsarbetet använda denna i största möjliga mån.
 - Information om SM och StyM skall i förhand publiceras på Discord, Instagram och sektionens webbplats.
 
 ## 4 Regler för massutskick via e-post
 
 - I ämnesraden ska det klart och tydligt framgå att mailet gäller sektionsaktivitet.  
-  Till exempel genom att inkludera IT-Sektionen i titeln enligt formatet “`IT-Sektionen | <titel>`“.
+  Till exempel genom att inkludera IT-Sektionen i titeln enligt formatet "`IT-Sektionen | <titel>`".

--- a/pm/swe/pm_for_insignia.md
+++ b/pm/swe/pm_for_insignia.md
@@ -19,26 +19,17 @@ För ändring av ändring av denna PM krävs beslut taget med kvalificerad major
 
 ### 2.1 Officiellt Emblem
 
-Mikrochipets ben skall ha färgen laserviolett (#CC99FF, se §1.2 i sektionens
-stadga) och centrum skall ha en mörkare ton av samma färg (exempelvis
-`#403050`). Blixten skall vara vit (`#FFFFFF`).
-
-Sektionens
-logotyp kännetecknas av bokstäverna I och T utförda som två delar av en
-vertikal blixt, där I vilar uppe på T.
-Den ensamma blixten skall ha färgen laserviolett (`#CC99FF`, se §1.2 i
-sektionens stadga). Alternativt kan den undre delen ha en mörkare ton av
-samma färg (exempelvis `#403050`).
-I fall där blixten inte utan svårigheter kan användas skall den inneslutas i en
-45 grader vinklad kvadrat som föreställer ett stiliserat mikrochip.
+Sektionens logotyp kännetecknas av bokstäverna I och T utförda som två delar av en vertikal blixt, där I vilar uppe på T.
+Den ensamma blixten skall ha färgen laserviolett (`#CC99FF`, se §1.2 i sektionens stadga).
+Alternativt kan den undre delen ha en mörkare ton av samma färg (exempelvis `#403050`).
+I fall där blixten inte utan svårigheter kan användas skall den inneslutas i en 45 grader vinklad kvadrat som föreställer ett stiliserat mikrochip.
 
 Den officiella logotypen ser ut som följer:
 
 ![Sektionens logotyp, i färg](./img/logo-it-1500px.png)
 
-Mikrochipets ben skall ha färgen laserviolett (`#CC99FF`, se §1.2 i sektionens
-stadga) och centrum skall ha en mörkare ton av samma färg (exempelvis
-`#403050`). Blixten skall vara vit (`#FFFFFF`).
+Mikrochipets ben skall ha färgen laserviolett (`#CC99FF`, se §1.2 i sektionens stadga) och centrum skall ha en mörkare ton av samma färg (exempelvis `#403050`).
+Blixten skall vara vit (`#FFFFFF`).
 
 ### 2.2 Enfärgat Emblem
 

--- a/pm/swe/pm_for_iterativa_klubben.md
+++ b/pm/swe/pm_for_iterativa_klubben.md
@@ -32,7 +32,7 @@ Intresserade sektionsmedlemmar får bli medlemmar i ITerativa Klubben.
 
 ITerativa Klubben har ingen egen ekonomi.
 
-## 3 Verksamhet
+## 4 Verksamhet
 
 ITerativa Klubbens verksamhetregleras under eget reglemente vilket är en del av denna PM.  
 Detta reglemente ändras i enlighet med bestämmelser i nämnda reglemente.

--- a/pm/swe/pm_for_jml.md
+++ b/pm/swe/pm_for_jml.md
@@ -63,7 +63,7 @@ Vice ordförande ska, i ordförandens frånvaro, fullgöra deras uppgifter och a
 
 ### 3.3 JML-Arbetsgrupp
 
-Arbetar med JML-frågor inom sektionen under Styrelseledamot med ansvar för JML-verksamhets ledning och hjälper Styrelseledamot med ansvar för JML-verksamhet att uppfylla sina uppgifter.  
+Arbetar med JML-frågor inom sektionen under Styrelseledamot med ansvar för JML-verksamhets ledning och hjälper Styrelseledamot med ansvar för JML-verksamhet att uppfylla sina uppgifter.
 
 ### 3.4 Internationell-kooordinator
 
@@ -76,9 +76,11 @@ I dessa uppgifter ingår:
 - Att samordna med den Internationella-arbetsgruppen och Mottagningsnämnden för att säkerställa att evenemang utarbetas, planeras och genomföras för alla nya masterstudenter och utbytesstudenter som påbörjar sina studier och som kommer att tillhöra sektionen under sina studier vid KTH.
 - Att arbeta för att all information finns tillgänglig på engelska.
 
-### 3.5 Internationell=Arbetsgrupp
+### 3.5 Internationell-Arbetsgrupp
 
-Arbetar med att främja internationella studenters ställning, integration och engagemang i sektionen under Internationell-koordinators ledning. De arbetar också tillsammans med den Internationella-koordinatorn och Mottagningsnämnden för att säkerställa att evenemang planeras och genomförs för alla nya masterstudenter och utbytesstudenter som påbörjar sina studier och som kommer att tillhöra sektionen under sina studier vid KTH. Medlemmar i den Internationella arbetsgruppen som aktivt har bidragit med totalt 25 arbetstimmar under en 4-månadersperiod är berättigade till en GPA-boost på 0,2 för utbytesstudier enligt beslut av THS Head of International och den Internationella-koordinatorn.
+Arbetar med att främja internationella studenters ställning, integration och engagemang i sektionen under Internationell-koordinators ledning.
+De arbetar också tillsammans med den Internationella-koordinatorn och Mottagningsnämnden för att säkerställa att evenemang planeras och genomförs för alla nya masterstudenter och utbytesstudenter som påbörjar sina studier och som kommer att tillhöra sektionen under sina studier vid KTH.
+Medlemmar i den Internationella arbetsgruppen som aktivt har bidragit med totalt 25 arbetstimmar under en 4-månadersperiod är berättigade till en GPA-boost på 0,2 för utbytesstudier enligt beslut av THS Head of International och den Internationella-koordinatorn.
 
 ## 4 Logotyp
 

--- a/pm/swe/pm_for_kommunikationsnamnden.md
+++ b/pm/swe/pm_for_kommunikationsnamnden.md
@@ -11,7 +11,7 @@ Kommunikationsnämndens syfte är att koordinera kommunikation, informationsflö
 ### 1.2 Historik
 
 Upprättat: 2014-01-01  
-Senast ändrat: 2023-12-05  
+Senast ändrat: 2023-12-05
 
 ### 1.3 Ändrande av PM
 
@@ -33,7 +33,7 @@ En enskild sektionsmedlem får endast inneha en styrelsepost åt gången.
 ### 2.1 Styrelseledamot med ansvar för Kommunikation
 
 Sammankallande och ordförande för Kommunikationsnämnden är Styrelseledamot med ansvar för Kommunikation, vilken ansvarar för att möten med hela nämnden hålls inför varje styrelsemöte.  
-Dennes ansvar och plikter regleras närmare i ”PM för Sektionens styrelse”.  
+Dennes ansvar och plikter regleras närmare i "PM för Sektionens styrelse".  
 Denne ska arbeta långsiktigt och strategiskt med att utveckla kommunikationen inom sektionen.
 
 ### 2.2 Vice ordförande
@@ -56,20 +56,20 @@ Den historieansvarige skall se till att nämnder upprätthåller sin del av PM f
 
 Kommunikationsnämnden ansvarar för:
 
-- att information om sektionens verksamhet publiceras på sektionens officiella webbplats och andra informationskanaler där sektionen har en officiell närvaro  
-- att i samråd med sektionens övriga organ vid behov hjälpa dessa att effektivare nå ut till sektionens medlemmar  
-- att ta emot och behandla önskemål och synpunkter på sektionens webbplats och andra informationskanaler  
-- att sköta den operativa driften av webbplatsen och mailkonton kopplade till sektionens domän(er)  
+- att information om sektionens verksamhet publiceras på sektionens officiella webbplats och andra informationskanaler där sektionen har en officiell närvaro
+- att i samråd med sektionens övriga organ vid behov hjälpa dessa att effektivare nå ut till sektionens medlemmar
+- att ta emot och behandla önskemål och synpunkter på sektionens webbplats och andra informationskanaler
+- att sköta den operativa driften av webbplatsen och mailkonton kopplade till sektionens domän(er)
 - att koordinera med webbutvecklare för större utvecklings- eller underhållsprojekt som inte kan skötas inom Kommunikationsnämnden
 
 ### 3.2 Profil
 
 Kommunikationsnämnden ansvarar för:
 
-- att ta fram overaller enligt ”Sektionens profildokument” och bedriva försäljning av dessa  
-- att ta fram profilsaker och bedriva försäljning av dessa  
-- att eftersträva medlemmarnas önskemål om eventuella nya profilsaker, genom att kartlägga önskemål med hjälp av undersökningar i samarbete med andra i nämnden  
-- att vid behov bistå sektionens organ med grafiskt material, exempelvis affischer, som behövs i organens verksamheter  
+- att ta fram overaller enligt "Sektionens profildokument" och bedriva försäljning av dessa
+- att ta fram profilsaker och bedriva försäljning av dessa
+- att eftersträva medlemmarnas önskemål om eventuella nya profilsaker, genom att kartlägga önskemål med hjälp av undersökningar i samarbete med andra i nämnden
+- att vid behov bistå sektionens organ med grafiskt material, exempelvis affischer, som behövs i organens verksamheter
 - Att tydligöra sektionens koppling till THS
 
 ### 3.3 Alumni
@@ -78,8 +78,8 @@ Historieansvarig ansvarar för sektionens kontakt med skolans alumni.
 
 I dessa uppgifter ingår:
 
-- att vara en kontaktperson mellan sektionen och alumnimedlemmarna  
-- att informera alumnimedlemmarna om de av sektionens event som kan vara intressanta för dessa  
+- att vara en kontaktperson mellan sektionen och alumnimedlemmarna
+- att informera alumnimedlemmarna om de av sektionens event som kan vara intressanta för dessa
 - att anordna event där sektionens medlemmar kan träffa och knyta kontakter med alumnimedlemmar, som t.ex. alumnipub
 
 ## 4 Ekonomi

--- a/pm/swe/pm_for_mottagningsnamnden.md
+++ b/pm/swe/pm_for_mottagningsnamnden.md
@@ -48,7 +48,7 @@ Benämnd Neurotisk Åskådare till Generalens Ounvikliga Nederlag (NÅGON).
 ### 2.3 Ledamot med ansvar för Budget
 
 Är ekonomisk samordnare och fungerar som kontaktperson med sektionens kassör.
-Dennes uppgift är att disponera Mottagningens budget.  
+Dennes uppgift är att disponera Mottagningens budget.
 
 ### 2.4 Ledamöter
 

--- a/pm/swe/pm_for_naringslivsnamnden.md
+++ b/pm/swe/pm_for_naringslivsnamnden.md
@@ -21,7 +21,7 @@ För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet p�
 
 Näringslivsnämndens styrelse består av:
 
-- Styrelseledamot med ansvar för Näringslivssamverkan  
+- Styrelseledamot med ansvar för Näringslivssamverkan
 - Vice ordförande
 
 Dessa väljs av SM.
@@ -31,10 +31,10 @@ Enskild sektionsmedlem får endast inneha en styrelsepost åt gången.
 
 ### 2.1 Styrelseledamot med ansvar för Näringslivssamverkan
 
-Sammankallande och ordförande för Näringslivsnämnden är Styrelseledamot med ansvar för näringslivssamverkan, vilken ansvarar för att möten med hela nämnden hålls inför varje styrelsemöte, samt erhåller ansvaret för kontraktsskrivning med företag.  
+Sammankallande och ordförande för Näringslivsnämnden är Styrelseledamot med ansvar för näringslivssamverkan, vilken ansvarar för att möten med hela nämnden hålls inför varje styrelsemöte, samt erhåller ansvaret för kontraktsskrivning med företag.
 
 Denne ska arbeta långsiktigt och strategiskt med att utveckla sektionens näringslivssamverkan.  
-Dennes ansvar och plikter regleras närmare i ”PM för Sektionens styrelse”.
+Dennes ansvar och plikter regleras närmare i "PM för Sektionens styrelse".
 
 ### 2.2 Vice ordförande
 
@@ -47,16 +47,16 @@ Utöver detta innehar vice ordförande det ansvar som fördelas mellan denne och
 
 Näringslivsnämnden ansvarar för:
 
-- att ta och hålla kontakt med näringsliv gällande företagsevenemang och aktiviteter.  
-- att anordna evenemang efter vad som efterfrågas och avtalas enligt ovanstående punkt.  
-- att utvärdera utförda evenemang och ta in feedback från både studenter och företag.  
+- att ta och hålla kontakt med näringsliv gällande företagsevenemang och aktiviteter.
+- att anordna evenemang efter vad som efterfrågas och avtalas enligt ovanstående punkt.
+- att utvärdera utförda evenemang och ta in feedback från både studenter och företag.
 - att arrangera Kista Arbetsmarknadsdag (KAM) under läsåret.
 
 ### 3.2 Spons
 
 Näringslivsnämnden ansvarar för:
 
-- att samordna sponsringen för alla sektionens organ.  
+- att samordna sponsringen för alla sektionens organ.
 - att välja in lämpligt antal nämndmedlemmar för att tillfredsställa sektionens sponsbehov, och arbetsleda dessa.
 
 ## 4 Ekonomi

--- a/pm/swe/pm_for_sektionens_profil.md
+++ b/pm/swe/pm_for_sektionens_profil.md
@@ -44,11 +44,11 @@ Revärerna behöver ej bytas ut om teknologen byter program, även om så är ö
 
 #### 2.2.2 Färg
 
-- För teknologer som går Civilingenjörsutbildning med inriktning Informationsteknik skall laservioletta revärer användas.  
-- För teknologer som går Civilingenjörsutbildning med inriktning Mikroelektronik skall limegröna revärer användas.  
-- För teknologer som går Högskoleingenjörsutbildning med inriktning Elektronik och datorteknik skall vita revärer användas.  
-- För teknologer som går Högskoleingenjörsutbildning med inriktning Datateknik skall cerisa revärer användas.  
-- För teknologer som går Kandidatutbildning med inriktning Affärssystem skall cerise- och porterbruna revärer användas.  
+- För teknologer som går Civilingenjörsutbildning med inriktning Informationsteknik skall laservioletta revärer användas.
+- För teknologer som går Civilingenjörsutbildning med inriktning Mikroelektronik skall limegröna revärer användas.
+- För teknologer som går Högskoleingenjörsutbildning med inriktning Elektronik och datorteknik skall vita revärer användas.
+- För teknologer som går Högskoleingenjörsutbildning med inriktning Datateknik skall cerisa revärer användas.
+- För teknologer som går Kandidatutbildning med inriktning Affärssystem skall cerise- och porterbruna revärer användas.
 - För teknologer som går kandidatutbildning med inriktning Informations- och kommunikationsteknik skall laservioletta revärer användas.
 
 #### 2.2.3 Gamla overaller

--- a/pm/swe/pm_for_sektionens_styrelse.md
+++ b/pm/swe/pm_for_sektionens_styrelse.md
@@ -19,7 +19,7 @@ För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet p�
 
 ### 2.1 Sammansättning
 
-Sektionens styrelse består av:  
+Sektionens styrelse består av:
 
 - Sektionens Ordförande
 - Sektionens vice Ordförande
@@ -34,7 +34,7 @@ Sektionens styrelse består av:
 
 ### 2.2 Suppleanter
 
-Styrelsens suppleanter är:  
+Styrelsens suppleanter är:
 
 - Vice kassör som suppleant för sektionens kassör.
 
@@ -50,18 +50,18 @@ Enskild sektionsmedlem får endast inneha en styrelse- eller styrelsesuppleantpo
 Styrelsen ansvarar för att samordna sektionens verksamhetsområden och förankra övergripande frågor gällande sektionens verksamhet samt sektionens strategiska och långsiktiga arbete.  
 Det operativa arbetet inom sektionen sköts av övriga nämnder och förtroendevalda, men styrelsen ska alltid finnas till som stöd för dessa, och ge riktlinjer för det operativa arbetet.
 
-Styrelsens specifika uppgifter är  
+Styrelsens specifika uppgifter är
 
-- att sköta sektionens löpande ärenden  
-- att förvalta budgeterade medel  
-- att samordna nämndernas verksamhet  
-- att efter skriftlig begäran från av sektionsmötet vald förtroendevald entlediga denne  
-- att vid behov utöva ordförandeskap för nämnd i dess ordförandes ställe  
-- att kalla till sektionsmöte  
-- att inför varje verksamhetsår utarbeta och föreslå en verksamhetsplan samt en budget för sektionsmötets godkännande  
-- att vid avgång gå igenom sektionens styrande dokument med tillträdande styrelse  
-- att se till att sektionens styrdokument inte strider mot THS stadga eller reglementen, varandra, eller är svårtolkade  
-- att äska pengar för sektionsavgift från THS  
+- att sköta sektionens löpande ärenden
+- att förvalta budgeterade medel
+- att samordna nämndernas verksamhet
+- att efter skriftlig begäran från av sektionsmötet vald förtroendevald entlediga denne
+- att vid behov utöva ordförandeskap för nämnd i dess ordförandes ställe
+- att kalla till sektionsmöte
+- att inför varje verksamhetsår utarbeta och föreslå en verksamhetsplan samt en budget för sektionsmötets godkännande
+- att vid avgång gå igenom sektionens styrande dokument med tillträdande styrelse
+- att se till att sektionens styrdokument inte strider mot THS stadga eller reglementen, varandra, eller är svårtolkade
+- att äska pengar för sektionsavgift från THS
 - att arbeta strategiskt mot en visionsplan för att utveckla sektionens långsiktiga verksamhet.
 
 ### 3.2 Individuellt ansvar
@@ -98,7 +98,7 @@ Kassören ska aktivt samarbeta med och delta i möten anordnat av THS Ekonomirå
 
 #### 3.2.5 Ledamot med ansvar för utbildningspåverkan
 
-Styrelseledamot med ansvar för utbildningspåverkan ska arbeta långsiktigt och strategiskt med utbildnings-, jämlikhets- och mångfaldsfrågor inom de program som finns inom sektionen och verka för att de ständigt förbättras intill det bästa är uppnått.  
+Styrelseledamot med ansvar för utbildningspåverkan ska arbeta långsiktigt och strategiskt med utbildnings-, jämlikhets- och mångfaldsfrågor inom de program som finns inom sektionen och verka för att de ständigt förbättras intill det bästa är uppnått.
 
 Ledamoten är sammankallande för Studienämnden, och leder det operativa arbetet de förtroendevalda inom nämnden utför.  
 Ledamoten fungerar även som stöd för dessa, samt som en länk mellan Studienämnden och styrelsen.  
@@ -107,15 +107,15 @@ Ledamoten ska aktivt samarbeta med och delta i möten anordnat av THS Utbildning
 
 #### 3.2.6 Ledamot med ansvar för studiesocial verksamhet
 
-Styrelseledamot med ansvar för studiesocial verksamhet ska arbeta långsiktigt med att utveckla studentlivet inom sektionen, och samarbeta med de operativa organ inom sektionen som utför arbetet.  
+Styrelseledamot med ansvar för studiesocial verksamhet ska arbeta långsiktigt med att utveckla studentlivet inom sektionen, och samarbeta med de operativa organ inom sektionen som utför arbetet.
 
 Ledamoten samordnar de nämnder inom sektionen som arbetar operativt med sektionens studiesociala verksamhet.  
-Ledamoten fungerar som en länk mellan dessa nämnder och styrelsen, och ansvarar därför för att träffa nämndernas ordförande inför varje styrelsemöte, för att säkra en bra insyn i deras arbete samt möjligheten att besvara  och driva deras frågor till styrelsen och vice versa.  
-Ledamoten ska i brist på bättre lämpad kandidat aktivt samarbeta med och delta i möten ordnade av THS Lokalråd.  
+Ledamoten fungerar som en länk mellan dessa nämnder och styrelsen, och ansvarar därför för att träffa nämndernas ordförande inför varje styrelsemöte, för att säkra en bra insyn i deras arbete samt möjligheten att besvara och driva deras frågor till styrelsen och vice versa.  
+Ledamoten ska i brist på bättre lämpad kandidat aktivt samarbeta med och delta i möten ordnade av THS Lokalråd.
 
 #### 3.2.7 Ledamot med ansvar för näringslivssamverkan
 
-Styrelseledamot med ansvar för näringslivssamverkan ska arbeta långsiktigt med att förbättra samarbetet mellan sektionen och näringslivet, samt stärka sektionens varumärke på arbetsmarknaden.  
+Styrelseledamot med ansvar för näringslivssamverkan ska arbeta långsiktigt med att förbättra samarbetet mellan sektionen och näringslivet, samt stärka sektionens varumärke på arbetsmarknaden.
 
 Ledamoten är sammankallande för Näringslivsnämnden, och leder det operativa arbetet de förtroendevalda inom nämnden utför.  
 Ledamoten fungerar även som stöd för dessa, samt som en länk mellan Näringslivsnämnden och styrelsen.  
@@ -124,7 +124,7 @@ Ledamoten ska aktivt samarbeta med och delta i möten anordnat av THS Näringsli
 
 #### 3.2.8 Ledamot med ansvar för kommunikation
 
-Styrelseledamot med ansvar för kommunikation ska arbeta långsiktigt och strategiskt med att stärka sektionens varumärke och dess koppling till THS, förbättra kommunikationen från sektionens organ till dess medlemmar och vice versa samt kartlägga studenternas åsikter och önskemål om sektionen.  
+Styrelseledamot med ansvar för kommunikation ska arbeta långsiktigt och strategiskt med att stärka sektionens varumärke och dess koppling till THS, förbättra kommunikationen från sektionens organ till dess medlemmar och vice versa samt kartlägga studenternas åsikter och önskemål om sektionen.
 
 Ledamoten är sammankallande för Kommunikationsnämnden, och leder det operativa arbetet de förtroendevalda inom nämnden utför.  
 Ledamoten fungerar även som stöd för dessa, samt som en länk mellan Kommunikationsnämnden och styrelsen.  
@@ -152,4 +152,4 @@ Vid frånvaro från styrelsemöte ska skriftlig rapportering insändas senast da
 
 ## 4 Motto
 
-Styrelsens motto är och skall förbli ”*Try my best to do always!*”.
+Styrelsens motto är och skall förbli "*Try my best to do always!*".

--- a/pm/swe/pm_for_sektionens_utrymmen.md
+++ b/pm/swe/pm_for_sektionens_utrymmen.md
@@ -22,7 +22,7 @@ För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet p�
 #### 2.1.1 Nyttjande
 
 Sektionen disponerar förvaringsutrymmen där sektionens organ kan lagra utrustning och material som används i organens verksamheter.  
-Samtliga organ har rätt att utnyttja dessa utrymmen i mån av tillgång och behov, så länge reglerna i detta PM efterföljs (se 2.1.7).  
+Samtliga organ har rätt att utnyttja dessa utrymmen i mån av tillgång och behov, så länge reglerna i detta PM efterföljs (se 2.1.7).
 
 Organ som önskar göra detta skall framställa sitt önskemål till sektionsstyrelsen, som fattar beslut i frågan.  
 I framställan skall omfattningen av organets behov tydligt framgå.
@@ -47,11 +47,12 @@ Utrustning och material som förvaras i ett utrymme får ej vara så placerad at
 
 #### 2.1.6 Förvaringskärl
 
-Utrustning och material skall i möjligaste mån vara förpackade, exempelvis i lådor, nät eller säckar. ”Lånade” förvaringsartiklar som inte ägs av organet (t ex kundvagnar) bör inte användas.
+Utrustning och material skall i möjligaste mån vara förpackade, exempelvis i lådor, nät eller säckar.
+"Lånade" förvaringsartiklar som inte ägs av organet (t.ex. kundvagnar) bör inte användas.
 
 #### 2.1.7 Regelefterlevnad
 
-Vid brott mot reglerna, som inte skyndsamt åtgärdas efter påpekande, förlorar organet vars medlem brutit mot reglerna all rätt till förvaring i det berörda utrymmet, samt eventuell behörighet som tilldelats organets medlemmar enligt 2.1.2
+Vid brott mot reglerna, som inte skyndsamt åtgärdas efter påpekande, förlorar organet vars medlem brutit mot reglerna all rätt till förvaring i det berörda utrymmet, samt eventuell behörighet som tilldelats organets medlemmar enligt 2.1.2.
 
 #### 2.1.8 Kvarlämnade föremål
 

--- a/pm/swe/pm_for_sektionsfanan.md
+++ b/pm/swe/pm_for_sektionsfanan.md
@@ -9,7 +9,7 @@ Denna PM reglerar sektionens fana vilken används för att representera sektione
 ### 1.2 Historik
 
 Upprättat: 2011-12-08  
-Senast ändrat: 2012-09-27
+Senast ändrat: 2022-09-27
 
 Sektionsfanan införskaffades 2011-09-21
 
@@ -30,8 +30,8 @@ Fanan förvaras av THS Fanborg.
 
 Sektionsfanan bärs vid, men inte begränsad till, följande tillfällen.
 
-- Valborgfirande på Skansen  
-- Nobelfesten  
-- Diplomeringar  
-- Promoveringar  
+- Valborgfirande på Skansen
+- Nobelfesten
+- Diplomeringar
+- Promoveringar
 - Välkomstceremonin i Stadshuset

--- a/pm/swe/pm_for_studienamnden.md
+++ b/pm/swe/pm_for_studienamnden.md
@@ -19,14 +19,14 @@ För ändrande av detta PM krävs ett beslut taget med kvalificerad majoritet p�
 
 ### 2.1 Sammansättning
 
-Studienämndens styrelse består av:  
+Studienämndens styrelse består av:
 
 - Styrelseledamoten med ansvar för utbildningsinflytande.
-- En programansvarig student (PAS) för vardera av EECS-skolans program som ges på campus KTH Kista på grundutbildningsnivå.  
+- En programansvarig student (PAS) för vardera av EECS-skolans program som ges på campus KTH Kista på grundutbildningsnivå.
 - En programansvarig student (PAS) som bevakar samtliga masterprogram vid EECS-skolan som ges på campus KTH Kista.
 
 Finner styrelsen det lämpligt kan nämnden ta in ytterligare medlemmar.  
-Enskild sektionsmedlem får endast inneha en styrelsepost åt gången.  
+Enskild sektionsmedlem får endast inneha en styrelsepost åt gången.
 
 ### 2.2 Tillsättning
 
@@ -37,31 +37,31 @@ Samtliga av studienämndens styrelserepresentanter väljs av sektionsmötet.
 ### 3.1 Styrelseledamot med ansvar för utbildningsinflytande
 
 Sammankallande och ordförande för studienämnden är styrelseledamoten med ansvar för utbildningsinflytande.  
-Styrelseledamoten ansvarar för att möten med hela nämnden hålls inför varje styrelsemöte.  
+Styrelseledamoten ansvarar för att möten med hela nämnden hålls inför varje styrelsemöte.
 
-Dennes ansvar och plikter regleras närmare i ”PM för Sektionens styrelse”.
+Dennes ansvar och plikter regleras närmare i "PM för Sektionens styrelse".
 
 ### 3.2 PAS
 
 En programansvarig student är ansvarig för studenternas utbildningsinflytande på programmet.
 
-I dess uppgifter ingår:  
+I dess uppgifter ingår:
 
-- Att genomföra och ta del av kurs- och programutvärderingar, samt se över resultaten av dessa.  
-- Att anordna årskursmöten för studenterna på programmet.  
-- Att arbeta för att förbättra det som kan och bör förbättras på programmet.  
+- Att genomföra och ta del av kurs- och programutvärderingar, samt se över resultaten av dessa.
+- Att anordna årskursmöten för studenterna på programmet.
+- Att arbeta för att förbättra det som kan och bör förbättras på programmet.
 - Att vara tillgänglig för synpunkter kring studiefrågor.
 
 ### 3.3 Ansvarig för masterprogram
 
 En programansvarig student är ansvarig för studenternas utbildningsinflytande på masterprogrammen i EECS-skolan som ges på campus KTH Kista.
 
-I dess uppgifter ingår:  
+I dess uppgifter ingår:
 
-- Att jobba för att kursnämnder tillsätts i masterkurser.  
-- Att genomföra och ta del av kurs- och programutvärderingar, samt se över resultaten av dessa.  
-- Att arbeta för att förbättra det som kan och bör förbättras på programmet.  
-- Att vara tillgänglig för synpunkter kring studiefrågor.  
+- Att jobba för att kursnämnder tillsätts i masterkurser.
+- Att genomföra och ta del av kurs- och programutvärderingar, samt se över resultaten av dessa.
+- Att arbeta för att förbättra det som kan och bör förbättras på programmet.
+- Att vara tillgänglig för synpunkter kring studiefrågor.
 - Att kommunicera på engelska då studenter som ej talar svenska är involverade.
 
 ## 4 Logotyp

--- a/pm/swe/pm_for_studiesociala_namnden.md
+++ b/pm/swe/pm_for_studiesociala_namnden.md
@@ -20,23 +20,23 @@ För ändrande av detta PM krävs ett beslut med kvalificerad majoritet på ett 
 
 ### 2.1 Sammanställning
 
-Studiesociala nämndens styrelse består av:  
+Studiesociala nämndens styrelse består av:
 
 - Ordförande samt styrelseledamot med ansvar för Studiesocial verksamhet.
 
 Studiesociala nämnden kan välja in fler styrelseledamöter.
-Enskild sektionsmedlem får endast inneha en styrelsepost åt gången.  
+Enskild sektionsmedlem får endast inneha en styrelsepost åt gången.
 
 ### 2.2 Tillsättning
 
-Samtliga av Studiesociala Nämndens styrelserepresentanter väljs av SM.  
+Samtliga av Studiesociala Nämndens styrelserepresentanter väljs av SM.
 
 ## 3 Verksamhet
 
 ### 3.1 Styrelseledamot med ansvar för Studiesocial verksamhet
 
-Sammankallande och ordförande för studiesociala nämnden är styrelseledamot med ansvar för studiesocial verksamhet.  
+Sammankallande och ordförande för studiesociala nämnden är styrelseledamot med ansvar för studiesocial verksamhet.
 
-Styrelseledamoten ansvarar för att möten med hela nämnden hålls inför varje styrelsemöte.  
+Styrelseledamoten ansvarar för att möten med hela nämnden hålls inför varje styrelsemöte.
 
-Dennes ansvar och plikter regleras i "PM för Sektionens Styrelse".  
+Dennes ansvar och plikter regleras i "PM för Sektionens Styrelse".

--- a/pm/swe/pm_for_traditioner.md
+++ b/pm/swe/pm_for_traditioner.md
@@ -62,9 +62,9 @@ En gasque för att avsluta en läsperiod och fira de avslutade tentorna.
 Utflykt för de mottagningsaktiva.  
 Brukar involvera teambuildning och en gasque.
 
-### 6.2 N0llegasque
+### 6.2 NØllegasque
 
-Den storslagna avslutningen för alla relaterade till Mottagningen, men främst för n0llan.
+Den storslagna avslutningen för alla relaterade till Mottagningen, men främst för nØllan.
 
 ## 7 ITK
 

--- a/pm/swe/pm_for_trygghetsrad.md
+++ b/pm/swe/pm_for_trygghetsrad.md
@@ -30,7 +30,7 @@ Tystnadsplikten kan förlängas till sektionsstyrelsen vid behov.
 Sektionens trygghetsråd ansvarar för
 
 - att företräda sektionens medlemmar i arbetsmiljöfrågor samt att se till att de förtroendevaldas tilldelade arbete går i linje med arbetsmiljölagstiftningen.
-- att hålla kontinuerlig kontakt med THS huvudskyddsombud.  
+- att hålla kontinuerlig kontakt med THS huvudskyddsombud.
 - att hålla kontinuerlig kontakt med sektionens representant i THS.
 
 ## 4 Regleringar

--- a/pm/swe/pm_for_uppforande.md
+++ b/pm/swe/pm_for_uppforande.md
@@ -12,7 +12,7 @@ Detta PM är en del av det förebyggande arbetet för att undvika oacceptabelt b
 ### 1.2 Historik
 
 Upprättat: 2023-12-05  
-Senast ändrat: 2023-12-05  
+Senast ändrat: 2023-12-05
 
 ### 1.3 Ändrande av PM
 

--- a/pm/swe/pm_for_valberedningen.md
+++ b/pm/swe/pm_for_valberedningen.md
@@ -24,7 +24,7 @@ Syftet med denna PM är att formalisera valberedningens arbete och förtydliga d
 
 ## 3. Verksamhet i allmänhet
 
-Det åligger valberedningen:  
+Det åligger valberedningen:
 
 - att marknadsföra de val som förrättas under det aktuella verksamhetsåret
 - att insamla nomineringar och kandidaturer,
@@ -71,7 +71,7 @@ Valberedningen får dock aldrig rekommendera en kandidat att dra tillbaka en kan
 
 Kandidaternas ansökningshandlingar samt valberedningens omdömen och förordanden ska offentliggöras i separata valhandlingar till sektionsmötet vid vilket val ska ske.  
 Valberedningen ska även i dessa handlingar beskriva det arbetssätt som använts under beredningen samt redogöra för vilka bedömningskriterier som använts vid bedömning av kandidaternas kvalifikationer och lämplighet.  
-Det totala antalet sökande till vardera post ska anges.  
+Det totala antalet sökande till vardera post ska anges.
 
 Valberedningen ska i dessa handlingar också redogöra för eventuella avvikelser från normal beredningsprocedur som har förekommit.
 
@@ -80,11 +80,11 @@ Valberedningen ska i dessa handlingar också redogöra för eventuella avvikelse
 Valberedningen kan under arbetets gång komma över potentiellt känslig information om de olika kandidaterna, både sådan som är relevant för valet och sådan som inte är det.  
 Det är av yttersta vikt att sådan information behandlas varsamt.
 
-All information om kandidaterna och valberedningens arbete är konfidentiell och får ej lämnas ut av valberedningen eller någon av dess medlemmar, med följande undantag:  
+All information om kandidaterna och valberedningens arbete är konfidentiell och får ej lämnas ut av valberedningen eller någon av dess medlemmar, med följande undantag:
 
-- Valhandlingar enligt ovan, samt annan information som valberedningen skriftligen delger sektionen är offentlig.  
+- Valhandlingar enligt ovan, samt annan information som valberedningen skriftligen delger sektionen är offentlig.
 - Valberedningen ska under sektionsmöte i relevant utsträckning besvara de frågor som ställs av sektionsmötet.  
-  Frågor till en enskild ledamot av valberedningen behöver dock inte besvaras, såvida de inte avser en i handlingarna anmäld avvikande uppfattning.  
+  Frågor till en enskild ledamot av valberedningen behöver dock inte besvaras, såvida de inte avser en i handlingarna anmäld avvikande uppfattning.
 - Även uppgifter som är att anse som känsliga ska delges sektionsmötet, om de bedöms vara av betydande vikt för valet.  
   Dock skall de berörda kandidaterna i förväg informeras om detta och därvid ges möjlighet att dra tillbaka sina kandidaturer.
 

--- a/scripts/validate_markdown.py
+++ b/scripts/validate_markdown.py
@@ -18,7 +18,6 @@ ENG_CHANGE = "Last revision:"
 
 class ValidationError(NamedTuple):
 	"""Represents a single validation error."""
-
 	file_path: Path
 	message: str
 	line_number: Optional[int] = None
@@ -103,10 +102,9 @@ def check_weird_quotes(lines: List[str], file_path: Path) -> List[ValidationErro
     """
     Checks for non-standard quote characters.
     """
-    pattern = re.compile(r'[“”„‟«»‘’‚‛′″]')
     errors: List[ValidationError] = []
     for i, line in enumerate(lines):
-        found = pattern.findall(line)
+        found = re.compile(r'[“”„‟«»‘’‚‛′″]').findall(line)
         if found:
             chars = ', '.join(sorted(set(found)))
             errors.append(ValidationError(file_path, f"Line has non-standard quote character: {chars}", i + 1))

--- a/scripts/validate_markdown.py
+++ b/scripts/validate_markdown.py
@@ -1,0 +1,242 @@
+import re
+import sys
+from pathlib import Path
+from typing import List, NamedTuple, Optional, Tuple
+
+DIRS_TO_CHECK = ["pm", "stadgar", "other_documents"]
+WARNING_WORDS = []
+ABBREVIATIONS = re.compile(r"\b(?:t\.ex|t\.o\.m|fr\.o\.m|d\.v\.s|m\.m|e\.g|i\.e|etc)\.", re.IGNORECASE)
+
+#The starting section of Memos that should always have the following sections
+SWE_FORMALIA = "Formalia"
+ENG_FORMALIA = "Formalities"
+SWE_FORMALIA_PARTS = ["Syfte", "Historik", "Ändrande av PM"]
+ENG_FORMALIA_PARTS = ["Purpose", "History", "Revising this Memo"]
+
+SWE_CHANGE = "Senast ändrat:"
+ENG_CHANGE = "Last revision:"
+
+class ValidationError(NamedTuple):
+	"""Represents a single validation error."""
+
+	file_path: Path
+	message: str
+	line_number: Optional[int] = None
+
+	def __str__(self) -> str:
+		"""Formats the error message for printing."""
+		location = f"{self.file_path}:{self.line_number}" if self.line_number else str(self.file_path)
+		return f"{location}: {self.message}"
+
+def check_periods(lines: List[str], file_path: Path) -> List[ValidationError]:
+	"""
+	Checks for lines with more than one period. Enforcing that each line is a single sentence.
+
+	It ignores periods used in URLs, abbreviations, and code blocks.
+	"""
+	errors: List[ValidationError] = []
+	for i, line in enumerate(lines):
+		text = line.strip()
+		if (
+			not text
+			or text.startswith("#")
+			or text.endswith(":")
+			or ("stadgar.md" in file_path.name and text.startswith("|"))
+		):
+			continue
+
+		text = re.sub(r"https?://\S+", "", text)  #Remove URLs
+		text = re.sub(r"\]\([^\)]+\)", "]", text)  #Remove Markdown links
+		text = re.sub(r"§\d+(?:\.\d+)*", "", text)  #Remove §1.2.3 section symbols
+		text = re.sub(r"\.(?=\d)", "", text)  #Remove dots in numbers
+		text = re.sub(r"^\d+\.", "", text)  #Remove list markers
+		text = ABBREVIATIONS.sub("", text)  #Remove abbreviations
+
+		if text.count(".") > 1:
+			errors.append(ValidationError(file_path, f"Line has {text.count('.')} periods, expected max 1.", i + 1))
+	return errors
+
+def check_warning_words(lines: List[str], file_path: Path) -> List[ValidationError]:
+	"""Checks for WARNING_WORDS that shouldn't be in the text."""
+	errors: List[ValidationError] = []
+	for i, line in enumerate(lines):
+		for word in WARNING_WORDS:
+			if re.search(r"\b" + re.escape(word) + r"\b", line, re.IGNORECASE):
+				errors.append(ValidationError(file_path, f"Found warning word: '{word}'", i + 1))
+	return errors
+
+def check_file_boundaries(content: str, file_path: Path) -> List[ValidationError]:
+	"""
+	Checks for missing trailing newline and checks that the file does not start with a newline.
+	"""
+	errors: List[ValidationError] = []
+	if content.startswith('\n') or content.startswith('\r\n'):
+		errors.append(ValidationError(file_path, "File starts with an empty line.", line_number=1))
+
+	if not content.endswith('\n'):
+		errors.append(ValidationError(file_path, "File is missing a trailing newline."))
+	elif content.endswith('\n\n') or content.endswith('\r\n\r\n'):
+		errors.append(ValidationError(file_path, "File has multiple trailing newlines."))
+	return errors
+
+def check_pm_structure(content: str, file_path: Path, lang: str) -> List[ValidationError]:
+	"""Validates Memo structure with required sections."""
+	errors: List[ValidationError] = []
+
+	if lang == "swe":
+		h1_check = SWE_FORMALIA
+		h2_checks = SWE_FORMALIA_PARTS
+	else:
+		h1_check = ENG_FORMALIA
+		h2_checks = ENG_FORMALIA_PARTS
+
+	if not re.search(r"^## \d+\.? " + re.escape(h1_check), content, re.MULTILINE):
+		errors.append(ValidationError(file_path, f"Missing '## X {h1_check}' section."))
+
+	missing_h2s = [h2 for h2 in h2_checks if not re.search(r"^### \d+\.\d+\.? " + re.escape(h2), content, re.MULTILINE)]
+	if missing_h2s:
+		errors.append(ValidationError(file_path, f"Missing '### X.Y' subsections: {', '.join(missing_h2s)}"))
+
+	return errors
+
+def check_weird_quotes(lines: List[str], file_path: Path) -> List[ValidationError]:
+    """
+    Checks for non-standard quote characters.
+    """
+    pattern = re.compile(r'[“”„‟«»‘’‚‛′″]')
+    errors: List[ValidationError] = []
+    for i, line in enumerate(lines):
+        found = pattern.findall(line)
+        if found:
+            chars = ', '.join(sorted(set(found)))
+            errors.append(ValidationError(file_path, f"Line has non-standard quote character: {chars}", i + 1))
+    return errors
+
+def extract_date(lines: List[str], prefix: str) -> Optional[Tuple[int, str]]:
+	"""Extracts YYYY-MM-DD date from a line starting with the given prefix."""
+	for i, line in enumerate(lines):
+		if line.strip().startswith(prefix):
+			match = re.search(r"(\d{4}-\d{2}-\d{2})", line)
+			if match:
+				return i + 1, match.group(1)
+	return None
+
+def extract_headers(lines: List[str]) -> List[Tuple[int, str]]:
+	"""Extracts all Markdown headers."""
+	return [(i + 1, line.strip()) for i, line in enumerate(lines) if line.strip().startswith("#")]
+
+def compare_files(swe_path: Path, swe_lines: List[str], eng_path: Path, eng_lines: List[str]) -> List[ValidationError]:
+	"""
+	Compares Swedish and English file versions for consistency.
+
+	- Line counts
+	- Header numbering
+	- Revision dates
+	"""
+	errors: List[ValidationError] = []
+
+	if len(swe_lines) != len(eng_lines):
+		errors.append(ValidationError(swe_path, f"Line count mismatch with {eng_path.name}: {len(swe_lines)} vs {len(eng_lines)}"))
+		return errors
+
+	swe_headers = extract_headers(swe_lines)
+	eng_headers = extract_headers(eng_lines)
+	if len(swe_headers) != len(eng_headers):
+		errors.append(ValidationError(swe_path, f"Header count mismatch with {eng_path.name}: {len(swe_headers)} vs {len(eng_headers)}"))
+	else:
+		for (swe_line, swe_header), (eng_line, eng_header) in zip(swe_headers, eng_headers):
+			if swe_line != eng_line:
+				errors.append(ValidationError(swe_path, f"Header line number mismatch for '{swe_header}'. SWE line:{swe_line} vs ENG line:{eng_line}", swe_line))
+				
+			swe_match = re.match(r"^(#+ [\d\.]+)", swe_header)
+			eng_match = re.match(r"^(#+ [\d\.]+)", eng_header)
+			if swe_match and eng_match and swe_match.group(1).strip(".") != eng_match.group(1).strip("."):
+				errors.append(ValidationError(swe_path, f"Header number mismatch: '{swe_header}' vs '{eng_header}' (ENG line {eng_line})", swe_line))
+
+	swe_date_info = extract_date(swe_lines, SWE_CHANGE)
+	eng_date_info = extract_date(eng_lines, ENG_CHANGE)
+	if swe_date_info and eng_date_info:
+		swe_line, swe_date = swe_date_info
+		eng_line, eng_date = eng_date_info
+		if swe_date != eng_date:
+			errors.append(ValidationError(swe_path, f"Date mismatch: SWE '{swe_date}' vs ENG '{eng_date}' (ENG line {eng_line})", swe_line))
+	elif swe_date_info and not eng_date_info:
+		swe_line, swe_date = swe_date_info
+		errors.append(ValidationError(swe_path, f"Missing '{ENG_CHANGE}' in ENG file (found '{swe_date}' in SWE).", swe_line))
+	return errors
+
+def process_file(file_path: Path, dir_name: str) -> Tuple[List[str], List[ValidationError]]:
+	try:
+		content = file_path.read_text(encoding="utf-8")
+		lines = content.splitlines()
+	except IOError as e:
+		return [], [ValidationError(file_path, f"Could not read file: {e}")]
+
+	errors: List[ValidationError] = []
+	lang = file_path.parent.name
+
+	errors.extend(check_periods(lines, file_path))
+	errors.extend(check_warning_words(lines, file_path))
+	errors.extend(check_file_boundaries(content, file_path))
+	errors.extend(check_weird_quotes(lines, file_path))
+
+	if dir_name == "pm":
+		errors.extend(check_pm_structure(content, file_path, lang))
+
+	return lines, errors
+
+def main() -> int:
+	all_errors: List[ValidationError] = []
+	valid_files = 0
+	invalid_files = 0
+	base_path = Path(".")
+
+	for dir_name in DIRS_TO_CHECK:
+		swe_dir = base_path/dir_name/"swe"
+		eng_dir = base_path/dir_name/"eng"
+
+		if not swe_dir.is_dir():
+			continue
+
+		for swe_path in swe_dir.glob("*.md"):
+			print(f"Checking {swe_path}...")
+			file_errors: List[ValidationError] = []
+
+			swe_lines, swe_errors = process_file(swe_path, dir_name)
+			file_errors.extend(swe_errors)
+
+			eng_path = eng_dir/swe_path.name
+			if eng_path.exists():
+				eng_lines, eng_errors = process_file(eng_path, dir_name)
+				file_errors.extend(eng_errors)
+				file_errors.extend(compare_files(swe_path, swe_lines, eng_path, eng_lines))
+			else:
+				file_errors.append(ValidationError(swe_path, f"Missing English version for {swe_path.name}"))
+
+			if file_errors:
+				invalid_files += 1
+				all_errors.extend(file_errors)
+			else:
+				valid_files += 1
+
+	print("" + "=" * 18)
+	print("VALIDATION SUMMARY")
+	print("=" * 18)
+
+	if all_errors:
+		all_errors.sort(key=lambda e: (str(e.file_path), e.line_number or 0))
+		for err in all_errors:
+			print(err)
+	else:
+		print("All checks passed!")
+
+	print("=" * 18)
+	print(f"Files Checked: {valid_files + invalid_files}")
+	print(f"Valid Files:   {valid_files}")
+	print(f"Invalid Files: {invalid_files}")
+	print("=" * 18)
+
+	return 1 if all_errors else 0
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/stadgar/eng/stadgar.md
+++ b/stadgar/eng/stadgar.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable-next-line -->
+
 ![The chapter's logo](./img/logo-it-1500px.png)
 
 # Statutes of the Information Technology Chapter
@@ -7,6 +8,7 @@ Adopted at the chapter meeting on 2008-12-11
 Last edit made at the chapter meeting on 2025-01-20
 
 <!-- markdownlint-disable MD056 MD058 -->
+
 \pagebreak
 
 | Table of contents
@@ -61,8 +63,8 @@ Last edit made at the chapter meeting on 2025-01-20
 | §9.2 Authority | | §10.2 Authority |
 | §9.3 Economy | | §10.3 Membership |
 | --- | | §10.4 Economy |
-| §11 Auditing and discharging  | | --- |
-| §11.1 Purpose | |  §12 Caucus |
+| §11 Auditing and discharging | | --- |
+| §11.1 Purpose | | §12 Caucus |
 | §11.2 Chapter auditor | | §12.1 Composition |
 | §11.3 Bias and chapter auditors | | §12.2 Tasks and responsibilities |
 | §11.4 Duties | | §12.3 Election procedure |
@@ -73,6 +75,7 @@ Last edit made at the chapter meeting on 2025-01-20
 | §13 Closing words |
 
 \pagebreak
+
 <!-- markdownlint-enable MD056 MD058 -->
 
 ## §1 General Information
@@ -102,7 +105,7 @@ To be considered a member one must pay the proper fees.
 ### §1.6 Authorised signatory
 
 §1.6.1 The chapter's authorised signatories are the chapter president and the chapter treasurer.  
-They sign the chapter firm together.  
+They sign the chapter firm together.
 
 The chapter board may suggest other signatories that the chapter meeting can approve.
 
@@ -112,11 +115,11 @@ The chapter board may suggest other signatories that the chapter meeting can app
 
 §1.7.1 The different bodies of the chapter are:
 
-- The chapter meeting.  
-- The chapter board.  
-- The chapter committees.  
-- The chapter clubs.  
-- The chapter auditors.  
+- The chapter meeting.
+- The chapter board.
+- The chapter committees.
+- The chapter clubs.
+- The chapter auditors.
 - The chapter caucus.
 
 ### §1.8 Announcing decisions
@@ -127,7 +130,7 @@ The chapter board may suggest other signatories that the chapter meeting can app
 
 §1.9.1 Relative majority: most votes.  
 §1.9.2 Qualified majority: > 2/3.  
-§1.9.3 Unanimous: all votes.  
+§1.9.3 Unanimous: all votes.
 
 ### §1.10 The chapter's birthday
 
@@ -166,8 +169,8 @@ Deviations from §2.2 cannot be made.
 
 ### §2.3 Memos
 
-§2.3.1 Memos regulate parts of the chapter where the statutes are not sufficiently
-detailed. Memos are always subordinate to the chapter statutes.
+§2.3.1 Memos regulate parts of the chapter where the statutes are not sufficiently detailed.
+Memos are always subordinate to the chapter statutes.
 
 §2.3.2 The establishment and abolishment of memos is decided upon by the chapter meeting and requires a qualified majority.  
 Memos mentioned in the statutes cannot be abolished without a change to the statutes.
@@ -203,26 +206,26 @@ Decisions regarding the establishing and changing of such exceptions always requ
 §3.2.4 A committee with its own budget is required to make its accounting available to the chapter meeting and the chapter board.
 
 §3.2.5 Committees with their own budget are authorized separately by the committee president and treasurer unless otherwise is stated in the committee's governing memo.  
-The authorizing parties are responsible for the committee’s economy.  
+The authorizing parties are responsible for the committee's economy.  
 Committees without its own economy shall not have any signatories.
 
 ### §3.3 Responsibilities
 
 §3.3.1 It is the responsibility of all chapter bodies that conduct activities under the rule of the chapter:
 
-- to provide verifications regarding when the transaction took place, what it pertains to, what it amounted to, and who made it, for every commercial transaction.  
-- to keep it's own account book.  
-- to make an annual financial report.  
+- to provide verifications regarding when the transaction took place, what it pertains to, what it amounted to, and who made it, for every commercial transaction.
+- to keep it's own account book.
+- to make an annual financial report.
 - to make an annual operational report.
 
 §3.3.2 All annual financial reports, operational reports, economical reports, accounting records, and verification information shall be saved according to Swedish laws and regulations.
 
 ### §3.4 Budget
 
-§3.4.1 It is the responsibility of the departing chapter board together with the succeeding board to formulate a suggested budget for the next operational year, and to present it to the chapter meeting. The suggestion shall be made in the form of a proposition.
+§3.4.1 It is the responsibility of the departing chapter board together with the succeeding board to formulate a suggested budget for the next operational year, and to present it to the chapter meeting.
+The suggestion shall be made in the form of a proposition.
 
-§3.4.2 In order to make changes to an already accepted budget a qualified majority is
-required.
+§3.4.2 In order to make changes to an already accepted budget a qualified majority is required.
 
 ### §3.5 Dissolvement
 
@@ -240,19 +243,19 @@ required.
 
 §4.2.1 Regular members have the rights:
 
-- to attend the chapter meeting with the rights to speak and vote.  
-- to have any inquiry processed by the chapter meeting.  
-- to express their reservation against decisions made by the chapter meeting.  
-- to access the chapter's protocols and other documents.  
-- to vote in the elections for the union council.  
-- to stand as a candidate for any position of responsibility within the chapter and THS, except for the position of supervisor.  
-- to attend board meetings.  
-- to utilise of services provided by the chapter.  
+- to attend the chapter meeting with the rights to speak and vote.
+- to have any inquiry processed by the chapter meeting.
+- to express their reservation against decisions made by the chapter meeting.
+- to access the chapter's protocols and other documents.
+- to vote in the elections for the union council.
+- to stand as a candidate for any position of responsibility within the chapter and THS, except for the position of supervisor.
+- to attend board meetings.
+- to utilise of services provided by the chapter.
 - to wear the chapter's overalls with the chapter color and the chapter's insignia.
 
 §4.2.2 It is the responsibility of regular members:
 
-- to conform to decisions made by the chapter meeting and by the chapter's bodies.  
+- to conform to decisions made by the chapter meeting and by the chapter's bodies.
 - to pay the union- and chapter fee.
 
 ### §4.3 Supporting member
@@ -274,8 +277,8 @@ A decision is based on a nomination on a chapter meeting and does not require a 
 
 §4.4.4 An honorary member have the rights:
 
-- to attend chapter meetings with the right to speak.  
-- to attend board meetings.  
+- to attend chapter meetings with the right to speak.
+- to attend board meetings.
 - to receive an invitation to all major events held by the chapter.
 
 §4.4.5 An honorary member that has inflicted harm upon the chapter may be expulsed after a decision has been made with a qualified majority on a chapter meeting.
@@ -310,10 +313,10 @@ These may be supplemented with extraordinary meetings if required.
 The following count as regular meetings:
 
 - the election meeting, where the next year's trustees are chosen or approved in accordance with the chapter's regulatory documents.  
-  These must be held at least one month before the end of the operational year.  
+  These must be held at least one month before the end of the operational year.
 - the budget meeting, where the next year's budget is processed.  
   This meeting should be held after the election meeting but must always be held before the end of the working year.  
-  This meeting should also treat next year's operational plan.  
+  This meeting should also treat next year's operational plan.
 - the decharge meeting, where the decharge of the previous year's board is treated.  
   It must be held at the latest 6 months after the end of the previous operational year, in accordance with THS bylaws.
 
@@ -340,13 +343,13 @@ A postponed matter shall be processed during the next chapter meeting.
 
 §5.7.1 Decisions can only be made in matters prescribed by the chapter's regulatory documents, or that is brought up by a motion or follow-up motion, and is a part of the decided upon meeting agenda.
 
-§5.7.2 Decisions are made through parliamentary voting with relative majority unless
-stated otherwise in the chapter's regulatory documents.
+§5.7.2 Decisions are made through parliamentary voting with relative majority unless stated otherwise in the chapter's regulatory documents.
 
 §5.7.3 Voting and elections is performed through acclamation unless stated otherwise in the chapter's regulatory documents, or if a formal vote is demanded by a voting member.
 
 §5.7.4 A formal vote is done openly, unless stated otherwise in the chapter's regulatory documents or, if demanded by a voting member, through ballots.  
-The votes are counted by two persons, chosen individually from one another by the meeting, and is reported to the chairman of the meeting. Should the numbers diverge the vote is recounted.
+The votes are counted by two persons, chosen individually from one another by the meeting, and is reported to the chairman of the meeting.
+Should the numbers diverge the vote is recounted.
 
 §5.7.5 In the event that the votes are tied the meeting president has the casting vote except in the case of elections where chance shall decide.
 
@@ -445,13 +448,13 @@ If the decision regards economic spending a decision can only be made if the amo
 
 §7.4.1 The chapter board is responsible:
 
-- to prepare subjects to be addressed by the chapter meeting.  
-- to answer received motions.  
-- to provide meeting minutes for the chapter meeting.  
-- to execute decisions made by the chapter meeting.  
-- to take responsibility for the chapter's economy and the economy of its committees before the chapter meeting.  
-- to draw up an annual report.  
-- to if necessary call to extra chapter meetings.  
+- to prepare subjects to be addressed by the chapter meeting.
+- to answer received motions.
+- to provide meeting minutes for the chapter meeting.
+- to execute decisions made by the chapter meeting.
+- to take responsibility for the chapter's economy and the economy of its committees before the chapter meeting.
+- to draw up an annual report.
+- to if necessary call to extra chapter meetings.
 - to draw up proposals for a operational plan and a budget for the following year.
 
 ### §7.5 Board meetings
@@ -466,7 +469,7 @@ If the decision regards economic spending a decision can only be made if the amo
 
 §7.5.5 All chapter members have the right to attend board meetings.
 
-§7.5.6 The board has the right to hold the board meeting behind closed doors if the decision to do so is made with a qualified majority for it. In this case only auditors, co-opted persons, and persons with the right to vote may attend the meeting.
+§7.5.6 The board meeting has the right to decide by qualified majority that the meeting shall be held behind closed doors, whereby only the auditors, voting or co-opted people have the right to attend.
 
 ### §7.6 Summons
 
@@ -565,8 +568,8 @@ It's name and composition is regulated by a directive adopted at the time of con
 §10.1.1 An application for being approved as a chapter association shall be submitted in writing to the chapter board.  
 The application must contain:
 
-- the purpose of the association  
-- economic scope  
+- the purpose of the association
+- economic scope
 - a proposal for, or already adopted, memos or statutes for the association that do not contravene the chapter's statutes.
 
 §10.1.2 Approval of an association is decided upon by the chapter meeting after recommendation by the chapter board.
@@ -614,25 +617,25 @@ With exception to membership in any of the chapter's clubs.
 
 §11.4.1 It is the duty of the chapter audtors:
 
-- to on behalf of the chapter meeting continually audit the accounting and activities of the chapter board and other chapter bodies, in accordance with the chapter's and THS's statutes.  
+- to on behalf of the chapter meeting continually audit the accounting and activities of the chapter board and other chapter bodies, in accordance with the chapter's and THS's statutes.
 - to after the end of the operational year audit the accounting and annual work reports of the chapter board and other chapter bodies.
 
 ### §11.5 Rights
 
 §11.5.1 The chapter auditors have the rights:
 
-- to by demand view all expenditures, protocols, and minutes.  
-- to receive information regarding activities.  
-- to call on any chapter body for auditing.  
-- to monitor all chapter bodies with the right to speak and make suggestions.  
-- to make changes to the praxis for accounting.  
+- to by demand view all expenditures, protocols, and minutes.
+- to receive information regarding activities.
+- to call on any chapter body for auditing.
+- to monitor all chapter bodies with the right to speak and make suggestions.
+- to make changes to the praxis for accounting.
 - to request additional chapter meetings.
 
 ### §11.6 The audit report
 
 §11.6.1 Regarding the audit report the following applies:
 
-- it shall be handed in to the board at least ten (10) days before the chapter meeting where auditing is processed.  
+- it shall be handed in to the board at least ten (10) days before the chapter meeting where auditing is processed.
 - it must be signed by at least two (2) of the chapter's auditors.
 
 ### §11.7 Discharging

--- a/stadgar/swe/stadgar.md
+++ b/stadgar/swe/stadgar.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable-next-line -->
+
 ![](./img/logo-it-1500px.png)
 
 # Sektionen för Informationstekniks Stadgar
@@ -7,6 +8,7 @@ Antagna vid Sektionsmötet 2008-12-11
 Senast ändrade vid Sektionsmötet 2025-01-20
 
 <!-- markdownlint-disable MD056 MD058 -->
+
 \pagebreak
 
 | Innehållsförteckning
@@ -16,7 +18,7 @@ Senast ändrade vid Sektionsmötet 2025-01-20
 | §1.2 Färg | | §2.2 Stadgar |
 | §1.3 Ändamål | | §2.3 PM |
 | §1.4 Sammansättning | | §2.4 Tolkning av styrdokument |
-| §1.5 Verksamhetsår |  | --- |
+| §1.5 Verksamhetsår | | --- |
 | §1.6 Firmateckning |
 | §1.7 Struktur |
 | §1.8 Tillkännagivande av beslut |
@@ -46,7 +48,7 @@ Senast ändrade vid Sektionsmötet 2025-01-20
 | §7.2 Sammansättning | | §8.2 Nämndposter |
 | §7.3 Sektionspresidiet | | §8.3 Bemyndigande |
 | §7.4 Styrelsens ansvar | | §8.4 Protokoll |
-| §7.5 Sammanträden, styrelsemöte |  | §8.5 Medlemskap |
+| §7.5 Sammanträden, styrelsemöte | | §8.5 Medlemskap |
 | §7.6 Kallelse | | --- |
 | §7.7 Beslutsmässighet |
 | §7.8 Solidariskt beslutsfattande |
@@ -62,7 +64,7 @@ Senast ändrade vid Sektionsmötet 2025-01-20
 | §9.3 Ekonomi | | §10.3 Medlemskap |
 | --- | | §10.4 Ekonomi |
 | §11 Revision och ansvarsfrihet | | --- |
-| §11.1 Uppgift | |  §12 Valberedning |
+| §11.1 Uppgift | | §12 Valberedning |
 | §11.2 Sektionsrevisor | | §12.1 Sammansättning |
 | §11.3 Jäv hos sektionsrevisor | | §12.2 Ansvar och uppgifter |
 | §11.4 Åligganden | | §12.3 Valprocedur |
@@ -73,6 +75,7 @@ Senast ändrade vid Sektionsmötet 2025-01-20
 | §13 Slutord |
 
 \pagebreak
+
 <!-- markdownlint-enable MD056 MD058 -->
 
 ## §1 Allmänt
@@ -112,11 +115,11 @@ Sektionsstyrelsen kan även föreslå andra firmatecknare som sektionsmötet kan
 
 §1.7.1 Sektionens organ är:
 
-- Sektionsmötet.  
-- Sektionsstyrelsen.  
-- Sektionens nämnder.  
-- Sektionens klubbar.  
-- Sektionsrevisorerna.  
+- Sektionsmötet.
+- Sektionsstyrelsen.
+- Sektionens nämnder.
+- Sektionens klubbar.
+- Sektionsrevisorerna.
 - Sektionens valberedning.
 
 ### §1.8 Tillkännagivande av beslut
@@ -155,7 +158,7 @@ Vid eventuella tolkningstvister skall tolkningsrätt ligga på det svenska dokum
 §2.2.2 För ändring av dessa stadgar krävs bifall på beslut tagna på två på varandra följande sektionsmöten.
 
 §2.2.3 Avvikelse från stadgarna får göras om det enhälligt stöds av ett beslutsmässigt sektionsmöte.  
-Avvikelse får ej göras till nackdel för enskild medlem.  
+Avvikelse får ej göras till nackdel för enskild medlem.
 
 Det skall i protokollet motiveras varför sektionsmötet väljer att avvika från stadgarna.  
 Avvikelse får ej ske från §2.2.
@@ -176,7 +179,7 @@ PM som nämns i sektionens stadgar kan dock inte avskaffas utan stadgeändring.
 
 §2.3.4 Det åligger sektionsordförande att ansvara för upprättande samt ändrande av PM om inte annat anges i sagda PM.
 
-§2.3.5 En PM skall utformas så att den följer de regler som anges i ”PM för PM”.
+§2.3.5 En PM skall utformas så att den följer de regler som anges i "PM för PM".
 
 ### §2.4 Tolkning av styrdokument
 
@@ -210,9 +213,9 @@ Nämnder utan egen ekonomi skall inte ha en firmatecknare.
 
 §3.3.1 Alla sektionens organ som bedriver verksamhet i sektionens regi är skyldiga:
 
-- att för varje affärshändelse kunna uppvisa verifikationer som innehåller uppgifter om när affärshändelsen skett, vad den avser, vilket belopp den gäller samt vilken motpart den berör.  
-- att föra kassabok.  
-- att göra årsbokslut.  
+- att för varje affärshändelse kunna uppvisa verifikationer som innehåller uppgifter om när affärshändelsen skett, vad den avser, vilket belopp den gäller samt vilken motpart den berör.
+- att föra kassabok.
+- att göra årsbokslut.
 - att upprätta verksamhetsberättelse.
 
 §3.3.2 Samtliga av sektionens årsbokslut, verksamhetsberättelser, eventuella ekonomiska berättelser, kolumndagböcker och verifikationspärmar skall förvaras i enlighet med gällande svenska lagar och förordningar.
@@ -240,19 +243,19 @@ Förslaget från sektionsstyrelsen läggs fram som en proposition.
 
 §4.2.1 Ordinarie medlem har rätt:
 
-- att deltaga på sektionsmötet med yttrande- och rösträtt.  
-- att få viss fråga behandlad av sektionsmötet.  
-- att reservera sig mot sektionsmötets beslut.  
-- att ta del av sektionens protokoll och övriga handlingar.  
-- att rösta i val till Kårfullmäktige.  
-- att kandidera till samtliga förtroendeuppdrag inom sektionen och THS, inspektor undantaget.  
-- att närvara på styrelsemöte.  
-- att ta del av den service som sektionen erbjuder.  
+- att deltaga på sektionsmötet med yttrande- och rösträtt.
+- att få viss fråga behandlad av sektionsmötet.
+- att reservera sig mot sektionsmötets beslut.
+- att ta del av sektionens protokoll och övriga handlingar.
+- att rösta i val till Kårfullmäktige.
+- att kandidera till samtliga förtroendeuppdrag inom sektionen och THS, inspektor undantaget.
+- att närvara på styrelsemöte.
+- att ta del av den service som sektionen erbjuder.
 - att bära sektionens overall med sektionens färg och sektionens insignia.
 
 §4.2.2 Ordinarie medlem är skyldig:
 
-- att rätta sig efter sektionsmötets och andra sektionsorgans beslut.  
+- att rätta sig efter sektionsmötets och andra sektionsorgans beslut.
 - att erlägga kår- och sektionsavgift.
 
 ### §4.3 Stödmedlem
@@ -274,8 +277,8 @@ Beslut fattas efter nominering på sektionsmöte och beslut kan fattas utan för
 
 §4.4.4 Hedersmedlem har rätt:
 
-- att deltaga på sektionsmötet med yttranderätt.  
-- att närvara på styrelsemöte.  
+- att deltaga på sektionsmötet med yttranderätt.
+- att närvara på styrelsemöte.
 - att att erhålla en inbjudan till större evenemang anordnade av sektionen.
 
 §4.4.5 Hedersmedlem som misskött sig eller åsamkat sektionen skada kan efter beslut av sektionsmötet med kvalificerad majoritet uteslutas.
@@ -310,10 +313,10 @@ Dessa kan kompletteras med extrainsatta vid behov.
 Som ordinarie möte räknas:
 
 - Valmötet, där kommande års förtroendevalda väljs eller godkänns i enlighet med sektionens styrdokument.  
-  Ska hållas minst en månad innan utgång av verksamhetsår.  
+  Ska hållas minst en månad innan utgång av verksamhetsår.
 - Budgetmötet, där kommande års budget fastställs.  
   Bör hållas efter valmötet men ska under alla omständigheter hållas innan utgång av innevarande verksamhetsår.  
-  Ska även behandla kommande års verksamhetsplan.  
+  Ska även behandla kommande års verksamhetsplan.
 - Dechargemötet, där fråga om ansvarsfrihet för föregående års sektionsstyrelse lyfts.  
   Ska hållas senast 6 månader efter avslutat verksamhetsår, i enlighet med THS reglemente.
 
@@ -445,13 +448,13 @@ Rör beslutet ekonomiska utgifter får beslut endast fattas om beloppet understi
 
 §7.4.1 Sektionsstyrelsen ansvarar för:
 
-- att bereda ärenden som ska behandlas av sektionsmötet.  
-- att svara på de motioner som inkommit.  
-- att upprätta föredragningslista till sektionsmötet.  
-- att verkställa av sektionsmötet fattade beslut.  
-- att inför sektionsmötet bära ansvaret för sektionens och sektionsnämndernas ekonomi.  
-- att upprätta verksamhetsberättelse.  
-- att vid behov kalla till extra sektionsmöte.  
+- att bereda ärenden som ska behandlas av sektionsmötet.
+- att svara på de motioner som inkommit.
+- att upprätta föredragningslista till sektionsmötet.
+- att verkställa av sektionsmötet fattade beslut.
+- att inför sektionsmötet bära ansvaret för sektionens och sektionsnämndernas ekonomi.
+- att upprätta verksamhetsberättelse.
+- att vid behov kalla till extra sektionsmöte.
 - att ta fram förslag till verksamhetsplan och budget.
 
 ### §7.5 Sammanträden, styrelsemöte
@@ -565,8 +568,8 @@ Dess namn, ändamål, och sammansättning regleras i ett direktiv som upprättas
 §10.1.1 Ansökan om godkännande av förening lämnas skriftligen till sektionsstyrelsen.  
 Ansökan skall innehålla:
 
-- föreningens grundtanke  
-- ekonomisk omfattning  
+- föreningens grundtanke
+- ekonomisk omfattning
 - ett förslag till, eller en antagen, PM eller stadgar för föreningen som ej strider mot sektionens stadgar.
 
 §10.1.2 Godkännande av en förening sker genom beslut på sektionsmötet efter förordande av sektionsstyrelsen.
@@ -614,25 +617,25 @@ Undantaget är medlemskap i sektionens klubbar.
 
 §11.4.1 Det åligger sektionsrevisorerna:
 
-- att för sektionsmötets räkning kontinuerligt granska sektionsstyrelsens och övriga sektionsorgans förvaltning samt deras verksamhet i förhållande till sektionens och THS stadgar.  
+- att för sektionsmötets räkning kontinuerligt granska sektionsstyrelsens och övriga sektionsorgans förvaltning samt deras verksamhet i förhållande till sektionens och THS stadgar.
 - att efter verksamhetsårets slut granska sektionsstyrelsens och övriga sektionsorgans förvaltning samt deras verksamhetsberättelser.
 
 ### §11.5 Rättigheter
 
 §11.5.1 Sektionsrevisorerna äger rätt:
 
-- att efter begäran taga del av samtliga räkenskaper, protokoll och handlingar.  
-- att erhålla upplysningar rörande verksamheten.  
-- att inkalla samtliga sektionens organ för granskning.  
-- att med yttranderätt samt förslagsrätt övervaka samtliga sektionens organ.  
-- att ändra i praxis för redovisning.  
+- att efter begäran taga del av samtliga räkenskaper, protokoll och handlingar.
+- att erhålla upplysningar rörande verksamheten.
+- att inkalla samtliga sektionens organ för granskning.
+- att med yttranderätt samt förslagsrätt övervaka samtliga sektionens organ.
+- att ändra i praxis för redovisning.
 - att begära extra sektionsmöte.
 
 ### §11.6 Revisionsberättelsen
 
 §11.6.1 Beträffande revisionsberättelser gäller:
 
-- att senast tio (10) dagar före sektionsmötet där revision tas upp, inlämnas revisionsberättelse till sektionsstyrelsen.  
+- att senast tio (10) dagar före sektionsmötet där revision tas upp, inlämnas revisionsberättelse till sektionsstyrelsen.
 - att revisionsberättelse skall undertecknas av minst två av sektionsrevisorerna.
 
 ### §11.7 Ansvarsfrihet


### PR DESCRIPTION
- Add a Linter that checks all files for the repository rules. (these are not super strict, but check the most common problems)
- Add automatic reminder comments for all PRs with common mistakes and title warnings.
- Updates all statutes and memos to match the linter rules.
- Updates the README and adds both CONTRIBUTION and PR template files.